### PR TITLE
Nuke trailing whitespace

### DIFF
--- a/Metalib/_CoqProject
+++ b/Metalib/_CoqProject
@@ -6,14 +6,14 @@ CoqFSetInterface.v
 CoqListFacts.v
 CoqMSetDecide.v
 CoqMSetInterface.v
-CoqUniquenessTac.v
 CoqUniquenessTacEx.v
+CoqUniquenessTac.v
 FSetExtra.v
 FSetWeakNotin.v
 LibDefaultSimp.v
 LibLNgen.v
 LibTactics.v
+MetatheoryAtom.v
+Metatheory.v
 MSetExtra.v
 MSetWeakNotin.v
-Metatheory.v
-MetatheoryAtom.v

--- a/SF/lf/Imp.v
+++ b/SF/lf/Imp.v
@@ -7,11 +7,11 @@
     and Java.  Here is a familiar mathematical function written in
     Imp.
 
-     Z ::= X;; 
-     Y ::= 1;; 
-     WHILE not (Z = 0) DO 
-       Y ::= Y * Z;; 
-       Z ::= Z - 1 
+     Z ::= X;;
+     Y ::= 1;;
+     WHILE not (Z = 0) DO
+       Y ::= Y * Z;;
+       Z ::= Z - 1
      END
 *)
 

--- a/SF/lf/ImpCEvalFun.v
+++ b/SF/lf/ImpCEvalFun.v
@@ -205,7 +205,7 @@ Definition test_ceval (st:state) (c:com) :=
 Definition pup_to_n : com
   (* REPLACE THIS LINE WITH ":= _your_definition_ ." *). Admitted.
 
-(* 
+(*
 Example pup_to_n_1 :
   test_ceval (t_update empty_state X 5) pup_to_n
   = Some (0, 15, 0).

--- a/SF/lf/ImpParser.v
+++ b/SF/lf/ImpParser.v
@@ -226,7 +226,7 @@ end.
 
 (** Parse arithmetic expressions *)
 
-Fixpoint parsePrimaryExp (steps:nat) 
+Fixpoint parsePrimaryExp (steps:nat)
                          (xs : list token)
                        : optionE (aexp * list token) :=
   match steps with
@@ -294,27 +294,27 @@ match steps with
          SomeE (BTrue,rest)
      OR DO (u,rest) <-- expect "false" xs;
          SomeE (BFalse,rest)
-     OR DO (e,rest) <-- 
-            firstExpect "not" 
-               (parseAtomicExp steps') 
+     OR DO (e,rest) <--
+            firstExpect "not"
+               (parseAtomicExp steps')
                xs;
          SomeE (BNot e, rest)
-     OR DO (e,rest) <-- 
-              firstExpect "(" 
+     OR DO (e,rest) <--
+              firstExpect "("
                 (parseConjunctionExp steps') xs;
-          (DO (u,rest') <== expect ")" rest; 
+          (DO (u,rest') <== expect ")" rest;
               SomeE (e, rest'))
      OR DO (e, rest) <== parseProductExp steps' xs;
             (DO (e', rest') <--
-              firstExpect "==" 
+              firstExpect "=="
                 (parseAExp steps') rest;
               SomeE (BEq e e', rest')
              OR DO (e', rest') <--
-               firstExpect "<=" 
+               firstExpect "<="
                  (parseAExp steps') rest;
                SomeE (BLe e e', rest')
              OR
-               NoneE 
+               NoneE
       "Expected '==' or '<=' after arithmetic expression")
 end
 
@@ -337,24 +337,24 @@ Definition parseBExp := parseConjunctionExp.
 Check parseConjunctionExp.
 
 Definition testParsing {X : Type}
-           (p : nat -> 
+           (p : nat ->
                 list token ->
                 optionE (X * list token))
            (s : string) :=
-  let t := tokenize s in 
+  let t := tokenize s in
   p 100 t.
 
 (*
-Eval compute in 
+Eval compute in
   testParsing parseProductExp "x*y*(x*x)*x".
 
-Eval compute in 
-  testParsing parseConjunctionExp "not((x==x||x*x<=(x*x)*x)&&x==x". 
+Eval compute in
+  testParsing parseConjunctionExp "not((x==x||x*x<=(x*x)*x)&&x==x".
 *)
 
 (** Parsing commands: *)
 
-Fixpoint parseSimpleCommand (steps:nat) 
+Fixpoint parseSimpleCommand (steps:nat)
                             (xs : list token) :=
   match steps with
   | 0 => NoneE "Too many recursive calls"
@@ -364,19 +364,19 @@ Fixpoint parseSimpleCommand (steps:nat)
     OR DO (e,rest) <--
          firstExpect "IF" (parseBExp steps') xs;
        DO (c,rest')  <==
-         firstExpect "THEN" 
+         firstExpect "THEN"
            (parseSequencedCommand steps') rest;
        DO (c',rest'') <==
-         firstExpect "ELSE" 
+         firstExpect "ELSE"
            (parseSequencedCommand steps') rest';
        DO (u,rest''') <==
          expect "END" rest'';
        SomeE(IFB e THEN c ELSE c' FI, rest''')
     OR DO (e,rest) <--
-         firstExpect "WHILE" 
+         firstExpect "WHILE"
            (parseBExp steps') xs;
        DO (c,rest') <==
-         firstExpect "DO" 
+         firstExpect "DO"
            (parseSequencedCommand steps') rest;
        DO (u,rest'') <==
          expect "END" rest';
@@ -396,7 +396,7 @@ with parseSequencedCommand (steps:nat)
       DO (c, rest) <==
         parseSimpleCommand steps' xs;
       DO (c', rest') <--
-        firstExpect ";;" 
+        firstExpect ";;"
           (parseSequencedCommand steps') rest;
         SomeE(c ;; c', rest')
       OR

--- a/SF/lf/IndPrinciples.v
+++ b/SF/lf/IndPrinciples.v
@@ -230,7 +230,7 @@ Check tree_ind.
             (forall m : mytype X, P m ->
                forall n : nat, P (constr3 X m n)) ->
             forall m : mytype X, P m
-*) 
+*)
 (** [] *)
 
 (** **** Exercise: 1 star, optional (foo)  *)
@@ -244,7 +244,7 @@ Check tree_ind.
              (forall f1 : nat -> foo X Y,
                (forall n : nat, P (f1 n)) -> P (quux X Y f1)) ->
              forall f2 : foo X Y, P f2
-*) 
+*)
 (** [] *)
 
 (** **** Exercise: 1 star, optional (foo')  *)

--- a/SF/lf/IndProp.v
+++ b/SF/lf/IndProp.v
@@ -1444,27 +1444,27 @@ Inductive nostutter {X:Type} : list X -> Prop :=
 
 Example test_nostutter_1: nostutter [3;1;4;1;5;6].
 (* FILL IN HERE *) Admitted.
-(* 
+(*
   Proof. repeat constructor; apply beq_nat_false_iff; auto.
   Qed.
 *)
 
 Example test_nostutter_2:  nostutter (@nil nat).
 (* FILL IN HERE *) Admitted.
-(* 
+(*
   Proof. repeat constructor; apply beq_nat_false_iff; auto.
   Qed.
 *)
 
 Example test_nostutter_3:  nostutter [5].
 (* FILL IN HERE *) Admitted.
-(* 
+(*
   Proof. repeat constructor; apply beq_nat_false; auto. Qed.
 *)
 
 Example test_nostutter_4:      not (nostutter [3;1;1;4]).
 (* FILL IN HERE *) Admitted.
-(* 
+(*
   Proof. intro.
   repeat match goal with
     h: nostutter _ |- _ => inversion h; clear h; subst

--- a/SF/lf/Lists.v
+++ b/SF/lf/Lists.v
@@ -1010,7 +1010,7 @@ Proof.
 
 Module PartialMap.
 Export NatList.
-  
+
 Inductive partial_map : Type :=
   | empty  : partial_map
   | record : id -> nat -> partial_map -> partial_map.

--- a/SF/lf/Logic.v
+++ b/SF/lf/Logic.v
@@ -80,7 +80,7 @@ Check is_three.
 (* ===> nat -> Prop *)
 
 (** In Coq, functions that return propositions are said to define
-    _properties_ of their arguments. 
+    _properties_ of their arguments.
 
     For instance, here's a (polymorphic) property defining the
     familiar notion of an _injective function_. *)
@@ -246,7 +246,7 @@ Proof.
   split.
     - (* left *) apply HQ.
     - (* right *) apply HP.  Qed.
-  
+
 (** **** Exercise: 2 stars (and_assoc)  *)
 (** (In the following proof of associativity, notice how the _nested_
     intro pattern breaks the hypothesis [H : P /\ (Q /\ R)] down into

--- a/SF/lf/Maps.v
+++ b/SF/lf/Maps.v
@@ -34,9 +34,9 @@ Require Import Coq.Strings.String.
 Require Import Coq.Logic.FunctionalExtensionality.
 
 (** Documentation for the standard library can be found at
-    http://coq.inria.fr/library/.  
+    http://coq.inria.fr/library/.
 
-    The [Search] command is a good way to look for theorems involving 
+    The [Search] command is a good way to look for theorems involving
     objects of specific types.  Take a minute now to experiment with it. *)
 
 (* ################################################################# *)
@@ -145,7 +145,7 @@ Definition t_update {A:Type} (m : total_map A)
   fun x' => if beq_id x x' then v else m x'.
 
 (** This definition is a nice example of higher-order programming:
-    [t_update] takes a _function_ [m] and yields a new function 
+    [t_update] takes a _function_ [m] and yields a new function
     [fun x' => ...] that behaves like the desired map.
 
     For example, we can build a map taking [id]s to [bool]s, where [Id

--- a/SF/lf/Poly.v
+++ b/SF/lf/Poly.v
@@ -106,7 +106,7 @@ Check cons.
 
 (** Having to supply a type argument for each use of a list
     constructor may seem an awkward burden, but we will soon see
-    ways of reducing that burden. *) 
+    ways of reducing that burden. *)
 
 Check (cons nat 2 (cons nat 1 (nil nat))).
 
@@ -805,7 +805,7 @@ Definition option_map {X Y : Type} (f : X -> Y) (xo : option X)
     type parameters where necessary and use Coq to check that you've
     done so correctly.  (This exercise is not to be turned in; it is
     probably easiest to do it on a _copy_ of this file that you can
-    throw away afterwards.) 
+    throw away afterwards.)
 *)
 (** [] *)
 

--- a/SF/lf/Postscript.v
+++ b/SF/lf/Postscript.v
@@ -5,7 +5,7 @@
 (* ################################################################# *)
 (** * Looking Back *)
 
-(** We've covered quite a bit of ground so far.  Here's a quick review...  
+(** We've covered quite a bit of ground so far.  Here's a quick review...
 
    - _Functional programming_:
           - "declarative" programming style (recursion over persistent

--- a/SF/lf/Preface.v
+++ b/SF/lf/Preface.v
@@ -313,7 +313,7 @@
     readers.  Advanced exercises are for readers who want an extra
     challenge and a deeper cut at the material.
 
-    _Please do not post solutions to the exercises in a public place_. 
+    _Please do not post solutions to the exercises in a public place_.
     Software Foundations is widely used both for self-study and for
     university courses.  Having solutions easily available makes it
     much less useful for courses, which typically have graded homework
@@ -361,13 +361,13 @@
         Benjamin Pierce.
 
     To get started, please send an email to Benjamin Pierce, describing
-    yourself and how you plan to use the materials and including 
-       (1) the above copyright transfer text and 
+    yourself and how you plan to use the materials and including
+       (1) the above copyright transfer text and
        (2) the result of doing "htpasswd -s -n NAME"
-    where NAME is your preferred user name. 
+    where NAME is your preferred user name.
 
-    We'll set you up with access to the subversion repository and 
-    developers' mailing lists.  In the repository you'll find a 
+    We'll set you up with access to the subversion repository and
+    developers' mailing lists.  In the repository you'll find a
     file [INSTRUCTORS] with further instructions. *)
 
 (* ################################################################# *)

--- a/SF/lf/ProofObjects.v
+++ b/SF/lf/ProofObjects.v
@@ -143,7 +143,7 @@ Qed.
 
 (** At any given moment, Coq has constructed a term with a
     "hole" (indicated by [?Goal] here, and so on), and it knows what
-    type of evidence is needed to fill this hole.  
+    type of evidence is needed to fill this hole.
 
     Each hole corresponds to a subgoal, and the proof is
     finished when there are no more subgoals.  At this point, the
@@ -178,7 +178,7 @@ Theorem ev_8 : ev 8.
 Proof.
   (* FILL IN HERE *) Admitted.
 
-Definition ev_8' : ev 8 
+Definition ev_8' : ev 8
   (* REPLACE THIS LINE WITH ":= _your_definition_ ." *). Admitted.
 (** [] *)
 
@@ -368,7 +368,7 @@ Definition and_comm' P Q : P /\ Q <-> Q /\ P :=
 (** **** Exercise: 2 stars, optional (conj_fact)  *)
 (** Construct a proof object demonstrating the following proposition. *)
 
-Definition conj_fact : forall P Q R, P /\ Q -> Q /\ R -> P /\ R 
+Definition conj_fact : forall P Q R, P /\ Q -> Q /\ R -> P /\ R
   (* REPLACE THIS LINE WITH ":= _your_definition_ ." *). Admitted.
 (** [] *)
 
@@ -396,7 +396,7 @@ End Or.
 (** Try to write down an explicit proof object for [or_commut] (without
     using [Print] to peek at the ones we already defined!). *)
 
-Definition or_comm : forall P Q, P \/ Q -> Q \/ P 
+Definition or_comm : forall P Q, P \/ Q -> Q \/ P
   (* REPLACE THIS LINE WITH ":= _your_definition_ ." *). Admitted.
 (** [] *)
 
@@ -435,7 +435,7 @@ Definition some_nat_is_even : exists n, ev n :=
 (** **** Exercise: 2 stars, optional (ex_ev_Sn)  *)
 (** Complete the definition of the following proof object: *)
 
-Definition ex_ev_Sn : ex (fun n => ev (S n)) 
+Definition ex_ev_Sn : ex (fun n => ev (S n))
   (* REPLACE THIS LINE WITH ":= _your_definition_ ." *). Admitted.
 (** [] *)
 

--- a/SF/lf/Rel.v
+++ b/SF/lf/Rel.v
@@ -89,7 +89,7 @@ Theorem le_not_a_partial_function :
   ~ (partial_function le).
 Proof.
   unfold not. unfold partial_function. intros Hc.
-  assert (0 = 1) as Nonsense. { 
+  assert (0 = 1) as Nonsense. {
     apply Hc with (x := 0).
     - apply le_n.
     - apply le_S. apply le_n. }

--- a/SF/vfa/ADT.v
+++ b/SF/vfa/ADT.v
@@ -25,7 +25,7 @@ End TABLE.
    there's a type [table] of lookup-tables, a type [V] of values,
    and operators [empty], [get], [set] that satisfy the axioms
    [gempty], [gss], and [gso].
-  
+
   It's easy to make an implementation of [TABLE], using [Maps].
   Just for example, let's choose [V] to be [Type]. *)
 
@@ -43,7 +43,7 @@ Module MapsTable <: TABLE.
  Theorem gempty: forall k, get k empty = default.
    Proof. intros. reflexivity. Qed.
  Theorem gss: forall k v t,  get k (set k v t) = v.
-   Proof. intros. unfold get, set. apply t_update_eq. Qed.  
+   Proof. intros. unfold get, set. apply t_update_eq. Qed.
  Theorem gso: forall j k v t, j<>k -> get j (set k v t) = get j t.
    Proof. intros. unfold get, set. apply t_update_neq.
        congruence.
@@ -67,7 +67,7 @@ Eval compute in MapsTable.get 1 (MapsTable.set 3 unit (MapsTable.set 1 bool Maps
 
 (** So, [MapsTable] is an implementation of the [TABLE] abstract type.
 
-   The problem with [MapsTable] is that the [Maps] implementation is 
+   The problem with [MapsTable] is that the [Maps] implementation is
    very inefficient: linear time per [get] operation. If you do a sequence
    of [N] [get] and [set] operations, it can take time quadratic in [N].
    For a more efficient implementation, let's use our search trees. *)
@@ -99,12 +99,12 @@ Module TreeTable <: TABLE.
 (** Prove this using techniques similar to the proof of [gss] just above. *)
 
  Theorem gso: forall j k v t,  j<>k -> get j (set k v t) = get j t.
-   Proof. 
+   Proof.
  (* FILL IN HERE *) Admitted.
 (** [] *)
 End TreeTable.
 
-(** But suppose we don't have an unrealistically strong can-relate theorem? 
+(** But suppose we don't have an unrealistically strong can-relate theorem?
    Remember the type of the "ordinary" can_relate: *)
 
 Check can_relate.
@@ -117,8 +117,8 @@ Check can_relate.
    the representation invariant.  We must ensure that  the client of an ADT
    cannot "forge" values, that is, cannot coerce the representation type into
    the abstract type; especially ill-formed values of the representation type.
-   This "unforgeability" is enforced in some real programming languages:  
-   ML (Standard ML or Ocaml) with its module system; Java, whose Classes 
+   This "unforgeability" is enforced in some real programming languages:
+   ML (Standard ML or Ocaml) with its module system; Java, whose Classes
    have "private variables" that the client cannot see.
 *)
 
@@ -149,12 +149,12 @@ Module TreeTable2 <: TABLE.
  Definition default : V := Prop.
  Definition table := {x | SearchTree V x}.
  Definition key := nat.
- Definition empty : table := 
+ Definition empty : table :=
    exist (SearchTree V) (empty_tree V) (empty_tree_SearchTree V).
- Definition get (k: key) (m: table) : V := 
+ Definition get (k: key) (m: table) : V :=
           (lookup V default k (proj1_sig m)).
  Definition set (k: key) (v: V) (m: table) : table :=
-   exist (SearchTree V) (insert V k v (proj1_sig m)) 
+   exist (SearchTree V) (insert V k v (proj1_sig m))
           (insert_SearchTree _ _ _ _ (proj2_sig m)).
 
  Theorem gempty: forall k, get k empty = default.
@@ -164,15 +164,15 @@ Module TreeTable2 <: TABLE.
   Proof. intros. unfold get, set.
     unfold table in t.
 
-(** Now: [t] is a package with two components: 
-     The first component is a tree, and the second component is 
+(** Now: [t] is a package with two components:
+     The first component is a tree, and the second component is
      a proof that the first component has the SearchTree property.
     We can destruct [t] to see that more clearly. *)
 
     destruct t as [a Ha].
     (* Watch what this [simpl] does: *)
     simpl.
-    (* Now we can use [can_relate] instead of [unrealistically_strong_can_relate]: *) 
+    (* Now we can use [can_relate] instead of [unrealistically_strong_can_relate]: *)
     destruct (can_relate V default a Ha) as [cts H].
     pose proof (insert_relate V default k v a cts H).
     pose proof (lookup_relate V default k _ _ H0).
@@ -184,7 +184,7 @@ Module TreeTable2 <: TABLE.
      don't use [unrealistically_strong_can_relate]. *)
 
  Theorem gso: forall j k v t,  j<>k -> get j (set k v t) = get j t.
-   Proof. 
+   Proof.
  (* FILL IN HERE *) Admitted.
 (** [] *)
 End TreeTable2.
@@ -202,7 +202,7 @@ Variable default: V.
 (** Step 1.  Define a _representation invariant_.
   (In the case of search trees,
   the representation invariant is the [SearchTree] predicate.)
-  Prove that each operation on the data type _preserves_ the 
+  Prove that each operation on the data type _preserves_ the
   representation invariant.  For example: *)
 
 Check (empty_tree_SearchTree V).
@@ -268,9 +268,9 @@ Import ListNotations.
 
 (** Here's the Fibonacci function. *)
 
-Fixpoint fibonacci (n: nat) := 
+Fixpoint fibonacci (n: nat) :=
  match n with
- | 0 => 1 
+ | 0 => 1
  | S i => match i with 0 => 1 | S j => fibonacci i + fibonacci j end
  end.
 
@@ -303,7 +303,7 @@ Module L <: LISTISH.
  Definition list := (nat*nat*nat)%type.
  Definition create (a b c: nat) : list := (a,b,c).
  Definition cons (i: nat) (il : list) := match il with (a,b,c) => (i,a,b) end.
- Definition nth (n: nat) (al: list) := 
+ Definition nth (n: nat) (al: list) :=
    match al with (a,b,c) =>
       match n with 0 => a | 1 => b | 2 => c | _ => 0 end
    end.
@@ -355,8 +355,8 @@ Lemma cons_relate : True.  (* change this line appropriately *)
 Lemma nth_relate : True.  (* change this line appropriately *)
 (* FILL IN HERE *) Admitted.
 
-(** Now, we will make these operators opaque.  Therefore, in the rest of 
-   the proofs in this exercise, you will not unfold their definitions.  Instead, 
+(** Now, we will make these operators opaque.  Therefore, in the rest of
+   the proofs in this exercise, you will not unfold their definitions.  Instead,
    you will just use the theorems [create_relate], [cons_relate], [nth_relate]. *)
 
 Opaque L.list.
@@ -367,13 +367,13 @@ Opaque O_Abs.
 
 Lemma step_relate:
   forall al al',
-   O_Abs al al' -> 
+   O_Abs al al' ->
    O_Abs (stepish al) (step al').
 Proof.
 (* FILL IN HERE *) Admitted.
 
 Lemma repeat_step_relate:
- forall n al al', 
+ forall n al al',
  O_Abs al al' ->
  O_Abs (repeat stepish al n) (repeat step al' n).
 Proof.
@@ -386,7 +386,7 @@ Proof.  (* No induction needed in this proof! *)
 
 (** **** Exercise: 2 stars, optional (fib_time_complexity)  *)
 (** Suppose you run these three programs call-by-value, that is,
-     as if they were ML programs.  
+     as if they were ML programs.
     [fibonacci N]
     [fib N]
     [fibish N]

--- a/SF/vfa/Binom.v
+++ b/SF/vfa/Binom.v
@@ -1,7 +1,7 @@
 (** * Binom: Binomial queues *)
 
 (** Implementation and correctness proof of fast mergeable priority queues
-   using binomial queues. 
+   using binomial queues.
 
   Operation [empty] is constant time,  [insert], [delete_max], and [merge]
   are logN time.  (Well, except that comparisons on [nat] take linear time.
@@ -14,7 +14,7 @@
   by Andrew W. Appel, 2016.
 
   Binomial Queues http://www.cs.princeton.edu/~appel/BQ.pdf
-  Section 9.7 of _Algorithms 3rd Edition in Java, Parts 1-4: 
+  Section 9.7 of _Algorithms 3rd Edition in Java, Parts 1-4:
     Fundamentals, Data Structures, Sorting, and Searching_,
   by Robert Sedgewick.  Addison-Wesley, 2002.
 *)
@@ -37,7 +37,7 @@ Inductive tree : Type :=
    is a list of trees.  The [i]'th element of the list is either [Leaf] or it is a
    power-of-2-heap with exactly [2^i] nodes.
 
-  This program will make sense to you if you've read the Sedgewick reading; 
+  This program will make sense to you if you've read the Sedgewick reading;
   otherwise it is rather mysterious.
 *)
 
@@ -47,13 +47,13 @@ Definition empty : priqueue := nil.
 
 Definition smash (t u:  tree) : tree :=
   match t , u with
-  |  Node x t1 Leaf, Node y u1 Leaf => 
+  |  Node x t1 Leaf, Node y u1 Leaf =>
                    if  x >? y then Node x (Node y u1 t1) Leaf
                                 else Node y (Node x t1 u1) Leaf
   | _ , _ => Leaf  (* arbitrary bogus tree *)
   end.
 
-Fixpoint carry (q: list tree) (t: tree) : list tree := 
+Fixpoint carry (q: list tree) (t: tree) : list tree :=
   match q, t with
   | nil, Leaf        => nil
   | nil, _            => t :: nil
@@ -62,19 +62,19 @@ Fixpoint carry (q: list tree) (t: tree) : list tree :=
   | u :: q', _       => Leaf :: carry q' (smash t u)
  end.
 
-Definition insert (x: key) (q: priqueue) : priqueue := 
+Definition insert (x: key) (q: priqueue) : priqueue :=
      carry q (Node x Leaf Leaf).
 
 Eval compute in fold_left (fun x q =>insert q x) [3;1;4;1;5;9;2;3;5] empty.
-(**  
+(**
     = [Node 5 Leaf Leaf;
        Leaf;
        Leaf;
        Node 9
           (Node 4 (Node 3 (Node 1 Leaf Leaf) (Node 1 Leaf Leaf))
-             (Node 3 (Node 2 Leaf Leaf) (Node 5 Leaf Leaf))) 
+             (Node 3 (Node 2 Leaf Leaf) (Node 5 Leaf Leaf)))
           Leaf]
-     : priqueue 
+     : priqueue
 >> *)
 
 Fixpoint join (p q: priqueue) (c: tree) : priqueue :=
@@ -96,7 +96,7 @@ Fixpoint unzip (t: tree) (cont: priqueue -> priqueue) : priqueue :=
   end.
 
 Definition heap_delete_max (t: tree) : priqueue :=
-  match t with 
+  match t with
     Node x t1 Leaf  => unzip t1 (fun u => u)
   | _ => nil   (* bogus value for ill-formed or empty trees *)
   end.
@@ -151,7 +151,7 @@ Fixpoint pow2heap' (n: nat) (m: key) (t: tree) :=
 
 (** [t] is a power-of-2 heap of depth [n] *)
 
-Definition pow2heap (n: nat) (t: tree) := 
+Definition pow2heap (n: nat) (t: tree) :=
   match t with
     Node m t1 Leaf => pow2heap' n m t1
   | _ => False
@@ -160,7 +160,7 @@ Definition pow2heap (n: nat) (t: tree) :=
 (** [l] is the [i]th tail of a binomial heap *)
 
 Fixpoint priq'  (i: nat) (l: list tree) : Prop :=
-   match l with 
+   match l with
   | t :: l' => (t=Leaf \/ pow2heap i t) /\ priq' (S i) l'
   | nil => True
  end.
@@ -190,8 +190,8 @@ Theorem smash_valid:
 (** [] *)
 
 (** **** Exercise: 3 stars (carry_valid)  *)
-Theorem carry_valid: 
-           forall n q,  priq' n q -> 
+Theorem carry_valid:
+           forall n q,  priq' n q ->
            forall t, (t=Leaf \/ pow2heap n t) -> priq' n (carry q t).
 (* FILL IN HERE *) Admitted.
 (** [] *)
@@ -228,14 +228,14 @@ Theorem delete_max_Some_priq:
 Inductive tree_elems: tree -> list key -> Prop :=
 | tree_elems_leaf: tree_elems Leaf nil
 | tree_elems_node:  forall bl br v tl tr b,
-           tree_elems tl bl -> 
-           tree_elems tr br -> 
+           tree_elems tl bl ->
+           tree_elems tr br ->
            Permutation b (v::bl++br) ->
            tree_elems (Node v tl tr) b.
 
 (** **** Exercise: 3 stars (priqueue_elems)  *)
 (** Make an inductive definition, similar to [tree_elems], to relate
-  a priority queue  "l"  to a list of all its elements.  
+  a priority queue  "l"  to a list of all its elements.
 
   As you can see in the definition of [tree_elems],  a [tree] relates to
   _any_ permutation of its keys, not just a single permutation.
@@ -243,7 +243,7 @@ Inductive tree_elems: tree -> list key -> Prop :=
   using (basically) the same technique as in [tree_elems].
 *)
 
-Inductive priqueue_elems: list tree -> list key -> Prop := 
+Inductive priqueue_elems: list tree -> list key -> Prop :=
              (* FILL IN HERE *)
 .
 (** [] *)
@@ -277,7 +277,7 @@ Theorem priqueue_elems_ext: forall q e1 e2,
 (** [] *)
 
 (** **** Exercise: 2 stars (abs_perm)  *)
-Theorem abs_perm: forall p al bl, 
+Theorem abs_perm: forall p al bl,
    priq p -> Abs p al -> Abs p bl -> Permutation al bl.
 Proof.
 (* FILL IN HERE *) Admitted.
@@ -316,30 +316,30 @@ Theorem smash_elems: forall n t u bt bu,
 (**  Some of these proofs are quite long, but they're not especially tricky. *)
 
 (** **** Exercise: 4 stars, optional (carry_elems)  *)
-Theorem carry_elems: 
-      forall n q,  priq' n q -> 
-      forall t, (t=Leaf \/ pow2heap n t) -> 
-      forall eq et, priqueue_elems q eq -> 
-                          tree_elems t et ->  
+Theorem carry_elems:
+      forall n q,  priq' n q ->
+      forall t, (t=Leaf \/ pow2heap n t) ->
+      forall eq et, priqueue_elems q eq ->
+                          tree_elems t et ->
                           priqueue_elems (carry q t) (eq++et).
 (* FILL IN HERE *) Admitted.
 (** [] *)
 
 (** **** Exercise: 2 stars, optional (insert_elems)  *)
-Theorem insert_relate: 
+Theorem insert_relate:
         forall p al k, priq p -> Abs p al -> Abs (insert k p) (k::al).
 (* FILL IN HERE *) Admitted.
 (** [] *)
 
 (** **** Exercise: 4 stars, optional (join_elems)  *)
-Theorem join_elems: 
-                forall p q c n, 
-                      priq' n p -> 
-                      priq' n q -> 
+Theorem join_elems:
+                forall p q c n,
+                      priq' n p ->
+                      priq' n q ->
                       (c=Leaf \/ pow2heap n c) ->
-                  forall pe qe ce, 
-                             priqueue_elems p pe -> 
-                             priqueue_elems q qe -> 
+                  forall pe qe ce,
+                             priqueue_elems p pe ->
+                             priqueue_elems q qe ->
                              tree_elems c ce ->
                               priqueue_elems (join p q c) (ce++pe++qe).
 (* FILL IN HERE *) Admitted.
@@ -347,7 +347,7 @@ Theorem join_elems:
 
 (** **** Exercise: 2 stars, optional (merge_relate)  *)
 Theorem merge_relate:
-    forall p q pl ql al, 
+    forall p q pl ql al,
        priq p -> priq q ->
        Abs p pl -> Abs q ql -> Abs (merge p q) al ->
        Permutation al (pl++ql).
@@ -386,7 +386,7 @@ End BinomQueue.
 (** Adapt the program (but not necessarily the proof) to use Ocaml integers
   as keys, in the style shown in [Extract].   Write an ML program to
   exercise it with random inputs.  Compare the runtime to the implementation
-  from [Priqueue], also adapted for Ocaml integers. 
+  from [Priqueue], also adapted for Ocaml integers.
 *)
 (** [] *)
 

--- a/SF/vfa/Decide.v
+++ b/SF/vfa/Decide.v
@@ -16,45 +16,45 @@ Check Nat.ltb.  (* : nat -> nat -> bool *)
 
 (** The [Perm] chapter defined a tactic called [bdestruct] that
     does case analysis on (x <? y) while giving you hypotheses (above
-    the line) of the form (x<y).   This tactic is built using the [reflect] 
+    the line) of the form (x<y).   This tactic is built using the [reflect]
     type and the [blt_reflect] theorem. *)
 
 Print reflect.
 (* Inductive reflect (P : Prop) : bool -> Set :=
-    | ReflectT : P -> reflect P true 
+    | ReflectT : P -> reflect P true
     | ReflectF : ~ P -> reflect P false  *)
 
 Check blt_reflect.  (* : forall x y, reflect (x<y) (x <? y) *)
 
 (** The name [reflect] for this type is a reference to _computational
-   reflection_,  a technique in logic.  One takes a logical formula, or 
-   proposition, or predicate,  and designs a syntactic embedding of 
+   reflection_,  a technique in logic.  One takes a logical formula, or
+   proposition, or predicate,  and designs a syntactic embedding of
    this formula as an "object value" in the logic.  That is, _reflect_ the
-   formula back into the logic. Then one can design computations 
-   expressible inside the logic that manipulate these syntactic object 
+   formula back into the logic. Then one can design computations
+   expressible inside the logic that manipulate these syntactic object
    values.  Finally, one proves that the computations make transformations
    that are equivalent to derivations (or equivalences) in the logic.
 
    The first use of computational reflection was by Goedel, in 1931:
-   his syntactic embedding encoded formulas as natural numbers, a 
+   his syntactic embedding encoded formulas as natural numbers, a
    "Goedel numbering."  The second and third uses of reflection were
-   by Church and Turing, in 1936: they encoded (respectively) 
+   by Church and Turing, in 1936: they encoded (respectively)
    lambda-expressions and Turing machines.
 
    In Coq it is easy to do reflection, because the Calculus of Inductive
-   Constructions (CiC) has Inductive data types that can easily encode 
-   syntax trees.  We could, for example, take some of our propositional 
-   operators such as [and], [or], and make an [Inductive] type that is an 
+   Constructions (CiC) has Inductive data types that can easily encode
+   syntax trees.  We could, for example, take some of our propositional
+   operators such as [and], [or], and make an [Inductive] type that is an
    encoding of these, and build a computational reasoning system for
    boolean satisfiability.
 
-   But in this chapter I will show something much simpler.  When 
+   But in this chapter I will show something much simpler.  When
    reasoning about less-than comparisons on natural numbers, we have
    the advantage that [nat] already an inductive type; it is "pre-reflected,"
    in some sense.  (The same for [Z], [list], [bool], etc.)  *)
 
 (** Now, let's examine how [reflect] expresses the coherence between
-  [lt] and [ltb]. Suppose we have a value [v] whose type is 
+  [lt] and [ltb]. Suppose we have a value [v] whose type is
   [reflect (3<7) (3<?7)].  What is [v]?  Either it is
   - ReflectT [P] (3<?7), where [P] is a proof of [3<7],  and [3<?7] is [true], or
   - ReflectF [Q] (3<?7), where [Q] is a proof of [~(3<7)], and [3<?7] is [false].
@@ -113,8 +113,8 @@ Module ScratchPad.
 
    Suppose [Q]  is a proposition, that is, [Q: Prop].  We say [Q] is
    _decidable_ if there is an algorithm for computing a proof of
-   [Q] or [~Q].  More generally, when [P] is a predicate (a function 
-   from some type [T] to [Prop]), we say [P] is decidable when 
+   [Q] or [~Q].  More generally, when [P] is a predicate (a function
+   from some type [T] to [Prop]), we say [P] is decidable when
    [forall x:T, decidable(P)].
 
    We represent this concept in Coq by an inductive datatype: *)
@@ -147,7 +147,7 @@ Definition v2a: t2 := left (3<7) (2>3) less37.
   But since there are no proofs of 2>3, only [left] values (such as [v2a])
   exist.  That's OK. *)
 
-(** [sumbool] is in the Coq standard library, where there is [Notation] 
+(** [sumbool] is in the Coq standard library, where there is [Notation]
    for it:  the expression [ {A}+{B} ] means [sumbool A B]. *)
 
 Notation "{ A } + { B }" := (sumbool A B) : type_scope.
@@ -157,7 +157,7 @@ Notation "{ A } + { B }" := (sumbool A B) : type_scope.
 
 Definition t4 := forall a b, {a<b}+{~(a<b)}.
 
-(** That expression, [forall a b, {a<b}+{~(a<b)}], says that for any 
+(** That expression, [forall a b, {a<b}+{~(a<b)}], says that for any
  natural numbers [a] and [b], either [a<b] or [a>=b].  But it is _more_
  than that!  Because [sumbool] is an Inductive type with two constructors
  [left] and [right], then given the [{3<7}+{~(3<7)}] you can pattern-match
@@ -175,7 +175,7 @@ Eval compute in is_3_less_7. (* = true : bool *)
 
 Print t4.  (* = forall a b : nat, {a < b} + {~ a < b} *)
 
-(** Suppose there existed a value [lt_dec] of type [t4].  That would be a 
+(** Suppose there existed a value [lt_dec] of type [t4].  That would be a
   _decision procedure_ for the less-than function on natural numbers.
   For any nats [a] and [b], you could calculate [lt_dec a b], which would
   be either [left ...] (if [a<b] was provable) or [right ...] (if [~(a<b)] was
@@ -196,7 +196,7 @@ match blt_reflect a b with
 | ReflectF _ Q => right (a < b) (~ a < b) Q
 end.
 
-(** Another, equivalent way to define [lt_dec] is to use 
+(** Another, equivalent way to define [lt_dec] is to use
      definition-by-tactic: *)
 
 Definition lt_dec' (a: nat) (b: nat) : {a<b}+{~(a<b)}.
@@ -226,7 +226,7 @@ Module ScratchPad2.
 Locate sumbool. (* Coq.Init.Specif.sumbool *)
 Print sumbool.
 
-(** The output of [Print sumbool] explains that the first two arguments 
+(** The output of [Print sumbool] explains that the first two arguments
    of [left] and [right] are implicit.  We use them as follows (notice that
    [left] has only one explicit argument [P]:  *)
 
@@ -245,7 +245,7 @@ end.
 (** Now, let's use [le_dec] directly in the implementation of insertion
    sort, without mentioning [ltb] at all. *)
 
-Fixpoint insert (x:nat) (l: list nat) := 
+Fixpoint insert (x:nat) (l: list nat) :=
   match l with
   | nil => x::nil
   | h::t => if le_dec x h then x::h::t else h :: insert x t
@@ -257,7 +257,7 @@ Fixpoint sort (l: list nat) : list nat :=
   | h::t => insert h (sort t)
 end.
 
-Inductive sorted: list nat -> Prop := 
+Inductive sorted: list nat -> Prop :=
 | sorted_nil:
     sorted nil
 | sorted_1: forall x,
@@ -277,7 +277,7 @@ Proof.
 
    (** Look at the proof state now.  In the first subgoal, we have
       above the line, [Hle: a <= x].  In the second subgoal, we have
-      [Hgt: ~ (a < x)].  These are put there automatically by the 
+      [Hgt: ~ (a < x)].  These are put there automatically by the
       [destruct (le_dec a x)].  Now, the rest of the proof can proceed
       as it did in [Sort.v], but using [destruct (le_dec _ _)] instead of
       [bdestruct (_ <=? _)]. *)
@@ -297,7 +297,7 @@ Proof.
    is the Halting Problem (Turing, 1936): [T] is the type of Turing-machine
    descriptions, and [P(x)] is, Turing machine [x] halts.  The first, and not
    as famous, example is due to Church, 1936 (six months earlier): test
-   whether a lambda-expression has a normal form.  In 1936-37, as a 
+   whether a lambda-expression has a normal form.  In 1936-37, as a
    first-year PhD student before beginning his PhD thesis work, Turing
    proved these two problems are equivalent.
 
@@ -308,9 +308,9 @@ Proof.
 
    But [P \/ ~P] is a weaker statement than [ {P}+{~P} ], that is,
    [sumbool P (~P)].  From [ {P}+{~P} ] you can actually _calculate_ or
-   [compute] either [left (x:P)] or [right(y: ~P)].     From [P \/ ~P] you cannot 
-   [compute] whether [P] is true.  Yes, you can [destruct] it in a proof, 
-   but not in a calculation.  
+   [compute] either [left (x:P)] or [right(y: ~P)].     From [P \/ ~P] you cannot
+   [compute] whether [P] is true.  Yes, you can [destruct] it in a proof,
+   but not in a calculation.
 
    For most purposes its unnecessary to add the axiom [P \/ ~P] to Coq,
    because for specific predicates there's a specific way to prove [P \/ ~P]
@@ -329,7 +329,7 @@ Axiom lt_dec_axiom_1:  forall i j: nat, i<j \/ ~(i<j).
 
 (** Now, can we use this axiom to compute with?  *)
 
-(* Uncomment and try this: 
+(* Uncomment and try this:
 Definition max (i j: nat) : nat :=
    if lt_dec_axiom_1 i j then j else i.
 *)
@@ -360,7 +360,7 @@ Lemma prove_with_max_axiom:   max_with_axiom 3 7 = 7.
 Proof.
 unfold max_with_axiom.
 try reflexivity.  (* does not do anything, reflexivity fails *)
-(* uncomment this line and try it: 
+(* uncomment this line and try it:
    unfold lt_dec_axiom_2.
 *)
 destruct (lt_dec_axiom_2 3 7).
@@ -370,7 +370,7 @@ Qed.
 
 (** It is dangerous to add Axioms to Coq: if you add one that's inconsistent,
    then it leads to the ability to prove [False].  While that's a convenient way
-   to get a lot of things proved, it's unsound; the proofs are useless.  
+   to get a lot of things proved, it's unsound; the proofs are useless.
 
    The Axioms above, [lt_dec_axiom_1] and [lt_dec_axiom_2], are safe enough:
    they are consistent.  But they don't help in computation.  Axioms are not
@@ -448,7 +448,7 @@ Z_ge_dec: forall x y : Z, {(x >= y)%Z} + {~ (x >= y)%Z}
     [list_eq_dec] calculates for you a decidable equality for type [list A].
     Try it out: *)
 
-Definition list_nat_eq_dec: 
+Definition list_nat_eq_dec:
     (forall al bl : list nat, {al=bl}+{al<>bl}) :=
   list_eq_dec eq_nat_dec.
 
@@ -489,7 +489,7 @@ simpl.
 
    - With [reflect], you define _three_ things:  the operator in [Prop],
       the operator in [bool] (such as [ltb: nat -> nat -> bool], and the
-      theorem that relates them (such as [ltb_reflect]).  
+      theorem that relates them (such as [ltb_reflect]).
 
    Defining three things seems like more work than defining two.
    But it may be easier and more efficient.  Programming in [bool],

--- a/SF/vfa/Extract.v
+++ b/SF/vfa/Extract.v
@@ -13,7 +13,7 @@
 Require Import Perm.
 
 Module Sort1.
-Fixpoint insert (i:nat) (l: list nat) := 
+Fixpoint insert (i:nat) (l: list nat) :=
   match l with
   | nil => i::nil
   | h::t => if i <=? h then i::h::t else h :: insert i t
@@ -52,7 +52,7 @@ Recursive Extraction  sort.
 End Sort1.
 
 (** This is better.  But the program still uses a unary representation of
-  natural numbers:  the number 7 is really (S (S (S (S (S (S (S O))))))). which in 
+  natural numbers:  the number 7 is really (S (S (S (S (S (S (S O))))))). which in
   Ocaml will be a data structure that's seven pointers deep.  The [leb] function
   takes time proportional to the difference in value between [n] and [m],
   which is terrible.  We'd like natural numbers to be represented as Ocaml [int].
@@ -87,10 +87,10 @@ Open Scope Z_scope.
  a mathematical theory without actually constructing it.  The reason
  that's dangerous is that if your axioms are inconsistent, then you
  can prove [False], or in fact, you can prove _anything_, so all your
- proofs are worthless.  So we must take care!  
+ proofs are worthless.  So we must take care!
 
- Here, we will axiomatize a _very weak_ mathematical theory:  
- We claim that there exists some type [int] with a function [ltb], 
+ Here, we will axiomatize a _very weak_ mathematical theory:
+ We claim that there exists some type [int] with a function [ltb],
  so that [int] injects into [Z], and [ltb] corresponds to the < relation
  on Z.  That seems true enough (for example, take [int=Z]), but
  we're not _proving_ it here. *)
@@ -101,7 +101,7 @@ Extract Inlined Constant int => "int".  (* so, extract it that way! *)
 Parameter ltb: int -> int -> bool.  (* This is the Ocaml (<) operator. *)
 Extract Inlined Constant ltb => "(<)".  (* so, extract it that way! *)
 
-(** Now, we need to axiomatize [ltb] so that we can reason about 
+(** Now, we need to axiomatize [ltb] so that we can reason about
   programs that use it.  We need to take great care here: the
   axioms had better be consistent with Ocaml's behavior, otherwise
   our proofs will be meaningless.
@@ -112,7 +112,7 @@ Extract Inlined Constant ltb => "(<)".  (* so, extract it that way! *)
   Coq's [Z] type.  The reason to do this is then we get to use the [omega]
   tactic, and other Coq libraries about integer comparisons. *)
 
-Parameter int2Z: int -> Z.  
+Parameter int2Z: int -> Z.
 Axiom ltb_lt : forall n m : int, ltb n m = true <-> int2Z n < int2Z m.
 
 (** Both of these axioms are sound.  There does (abstractly) exist a
@@ -135,7 +135,7 @@ Axiom ltb_lt : forall n m : int, ltb n m = true <-> int2Z n < int2Z m.
        ocaml_plus a b = c <-> int2Z a + int2Z b = int2Z c.]
 
   The first two lines are OK:  there really is a "+" function in Ocaml,
-  and its type really is  [int -> int -> int].  
+  and its type really is  [int -> int -> int].
 
   But [ocaml_plus_plus] is unsound!   From it, you could prove,
 
@@ -195,7 +195,7 @@ Lemma t_update_eq : forall A (m: total_map A) x v, (t_update m x v) x = v.
 Proof.
   intros. unfold t_update.
   bdestruct (x=?x); auto.
-  omega. 
+  omega.
 Qed.
 
 Theorem t_update_neq : forall (X:Type) v x1 x2 (m : total_map X),
@@ -237,13 +237,13 @@ Definition empty_tree : tree := E.
 Fixpoint lookup (x: key) (t : tree) : V :=
   match t with
   | E => default
-  | T tl k v tr => if ltb x k then lookup x tl 
+  | T tl k v tr => if ltb x k then lookup x tl
                          else if ltb k x then lookup x tr
                          else v
   end.
 
 Fixpoint insert (x: key) (v: V) (s: tree) : tree :=
- match s with 
+ match s with
  | E => T E x v E
  | T a y v' b => if  ltb x y then T (insert x v a) y v' b
                         else if ltb y x then T a y v' (insert x v b)
@@ -302,7 +302,7 @@ End TREES.
 
 Recursive Extraction empty_tree insert lookup elements.
 
-(** Next, we will extract it into an Ocaml source file, and measure its 
+(** Next, we will extract it into an Ocaml source file, and measure its
   performance. *)
 
 Extraction "searchtree.ml" empty_tree insert lookup elements.
@@ -335,12 +335,12 @@ let print_test name (f: int -> int) n =
   in (print_string "Insert and lookup "; print_int n;
       print_string " "; print_string name; print_string " integers in ";
       print_float time; print_endline " seconds.")
-  
+
 let test_random n = print_test "random" (fun _ -> Random.int n) n
 let test_consec n = print_test "consecutive" (fun i -> n-i) n
 
 let run_tests() = (test_random 1000000; test_random 20000; test_consec 20000)
-		    
+		
 let _ = run_tests ()
 >> *)
 
@@ -381,7 +381,7 @@ Insert and lookup 20000 consecutive integers in 0.374 seconds.
    function [ltb]  that is abstract and uninstantiated (only during
    Extraction to Ocaml does [ltb] get instantiated).
 
-   So instead, we'll use the SearchTree module, 
+   So instead, we'll use the SearchTree module,
    where everything runs inside Coq. *)
 
 Require SearchTree.

--- a/SF/vfa/Maps.v
+++ b/SF/vfa/Maps.v
@@ -34,9 +34,9 @@ Require Import Coq.Bool.Bool.
 Require Import Coq.Logic.FunctionalExtensionality.
 
 (** Documentation for the standard library can be found at
-    http://coq.inria.fr/library/.  
+    http://coq.inria.fr/library/.
 
-    The [SearchAbout] command is a good way to look for theorems 
+    The [SearchAbout] command is a good way to look for theorems
     involving objects of specific types. *)
 
 (* ################################################################# *)

--- a/SF/vfa/Multiset.v
+++ b/SF/vfa/Multiset.v
@@ -220,9 +220,9 @@ Proof.
   clear v bl Heqcl.
 
   (** From this point on, you don't need induction.
-    Use the lemmas [perm_trans], [delete_contents], 
+    Use the lemmas [perm_trans], [delete_contents],
      [in_perm_delete], [contents_in].   At _certain points_
-     you'll need to unfold the definitions of 
+     you'll need to unfold the definitions of
      [multiset_delete], [union], [singleton]. *)
 
   (* FILL IN HERE *) Admitted.

--- a/SF/vfa/Perm.v
+++ b/SF/vfa/Perm.v
@@ -20,7 +20,7 @@ Require Export Coq.Bool.Bool.
 Require Export Coq.Arith.Arith.
 Require Export Coq.Arith.EqNat.
 Require Export Coq.omega.Omega.
-Require Export Coq.Lists.List. 
+Require Export Coq.Lists.List.
 Export ListNotations.
 Require Export Permutation.
 
@@ -46,7 +46,7 @@ Locate "<?".     (* x <? y  := Nat.ltb x y *)
 Check Nat.ltb_lt.
 (* : forall n m : nat, (n <? m) = true <-> n < m *)
 
-(** For some reason, the Coq library has [ <? ] and [ <=? ] 
+(** For some reason, the Coq library has [ <? ] and [ <=? ]
     notations, but is missing these three: *)
 
 Notation  "a >=? b" := (Nat.leb b a)
@@ -90,9 +90,9 @@ Qed.
     Suppose you have this simple program, [(if a <? 5 then a else 2)],
     and you want to prove that it evaluates to a number smaller than 6.
     You can use [blt_reflect] "by hand": *)
-    
+
 Example reflect_example1: forall a, (if a<?5 then a else 2) < 6.
-Proof. 
+Proof.
   intros.
   destruct (blt_reflect a 5) as [H|H].
   * (* Notice that [H] above the line has a [Prop]ositional
@@ -133,7 +133,7 @@ Ltac bdestruct X :=
      are more examples later. *)
 
 Example reflect_example2: forall a, (if a<?5 then a else 2) < 6.
-Proof. 
+Proof.
   intros.
   bdestruct (a<?5).  (* instead of: [destruct (blt_reflect a 5) as [H|H]]. *)
   * (* Notice that [H] above the line has a [Prop]ositional
@@ -153,18 +153,18 @@ Qed.
     [inversion] typically creates some equality facts, why not then
     [subst] ?   This motivates the following useful tactic, [inv]:  *)
 
-Ltac inv H := inversion H; clear H; subst. 
+Ltac inv H := inversion H; clear H; subst.
 
 (* ================================================================= *)
 (** ** Linear integer inequalities *)
 
-(** In our proofs about searching and sorting algorithms, we 
-    sometimes have to reason about the consequences of 
+(** In our proofs about searching and sorting algorithms, we
+    sometimes have to reason about the consequences of
     less-than and greater-than.  Here's a contrived example. *)
 
 Module Exploration1.
 
-Theorem omega_example1: 
+Theorem omega_example1:
  forall i j k,
     i < j ->
     ~ (k - 3 <= j) ->
@@ -176,10 +176,10 @@ Proof.
     Here's the hard way. *)
 
   (* try to remember the name of the lemma about negation and [<=] *)
-  SearchAbout (~ _ <= _ -> _). 
+  SearchAbout (~ _ <= _ -> _).
   apply not_le in H0.
   (* try to remember the name of the transitivity lemma about [>] *)
-  SearchAbout (_ > _ -> _ > _ -> _ > _).  
+  SearchAbout (_ > _ -> _ > _ -> _ > _).
   apply gt_trans with j.
   apply gt_trans with (k-3).
   (* _OBVIOUSLY_, [k] is greater than [k-3].  But _OOPS_,
@@ -190,16 +190,16 @@ Abort.
 Theorem bogus_subtraction: ~ (forall k:nat, k > k - 3).
 Proof.
   (* [intro] introduces exactly one thing, like [intros ?] *)
-  intro.  
+  intro.
   (* [specialize] applies a hypothesis to an argument *)
-  specialize (H O).  
+  specialize (H O).
   simpl in H. inversion H.
 Qed.
 
 (** With bogus subtraction, this omega_example1 theorem even True?
     Yes it is; let's try again, the hard way, to find the proof. *)
 
-Theorem omega_example1: 
+Theorem omega_example1:
  forall i j k,
     i < j ->
     ~ (k - 3 <= j) ->
@@ -210,7 +210,7 @@ Proof. (* try again! *)
   unfold gt in H0.
   unfold gt.
   (* try to remember the name ... *)
-  SearchAbout (_ < _ -> _ <= _ -> _ < _).  
+  SearchAbout (_ < _ -> _ <= _ -> _ < _).
   apply lt_le_trans with j.
   apply H.
   apply le_trans with (k-3).
@@ -222,7 +222,7 @@ Qed.  (* Oof!  That was exhausting and tedious.  *)
 
 (** And here's the easy way. *)
 
-Theorem omega_example2: 
+Theorem omega_example2:
  forall i j k,
     i < j ->
     ~ (k - 3 <= j) ->
@@ -248,7 +248,7 @@ Qed.
     Omega does _not_ understand other operators.  It treats things
     like [a*b] and [f x y] as if they were variables.  That is, it can
     prove [f x y > a*b -> f x y + 3 >= a*b], in the same way it would
-    prove [u > v -> u+3 >= v]. 
+    prove [u > v -> u+3 >= v].
 
     Now let's consider a silly little program: swap the first two
     elements of a list, if they are out of order. *)
@@ -388,7 +388,7 @@ Proof.
   reflexivity.
   simpl.
   bdestruct (b <? a).
-* 
+*
   simpl.
   bdestruct (a <? b).
   omega.
@@ -413,21 +413,21 @@ Locate Permutation. (* Inductive Coq.Sorting.Permutation.Permutation *)
 Check Permutation. (*  : forall {A : Type}, list A -> list A -> Prop *)
 
 (** We say "list [al] is a permutation of list [bl]",
-     written [Permutation al bl], if the elements of [al] can be 
+     written [Permutation al bl], if the elements of [al] can be
      reordered (without insertions or deletions) to get the list [bl]. *)
 
-Print Permutation. 
+Print Permutation.
 (*
  Inductive Permutation {A : Type} : list A -> list A -> Prop :=
     perm_nil : Permutation [] []
   | perm_skip : forall (x : A) (l l' : list A),
-                Permutation l l' -> 
+                Permutation l l' ->
                 Permutation (x :: l) (x :: l')
   | perm_swap : forall (x y : A) (l : list A),
                 Permutation (y :: x :: l) (x :: y :: l)
   | perm_trans : forall l l' l'' : list A,
-                 Permutation l l' -> 
-                 Permutation l' l'' -> 
+                 Permutation l l' ->
+                 Permutation l' l'' ->
                  Permutation l l''.
 *)
 
@@ -451,7 +451,7 @@ Print Permutation.
      - 1. If [Permutation al bl], then [length al = length bl].
      - 2. If [Permutation al bl], then [Permutation bl al].
      - 3. [[1;1]] is NOT a permutation of [[1;2]].
-     - 4. [[1;2;3;4]] IS a permutation of [[3;4;2;1]]. 
+     - 4. [[1;2;3;4]] IS a permutation of [[3;4;2;1]].
 
    YOUR ASSIGNMENT: Add three more properties. Write them here: *)
 
@@ -469,7 +469,7 @@ SearchAbout Permutation.  (* Browse through the results of this query! *)
 
 (** Let's use the permutation rules in the library to prove the
     following theorem. *)
-    
+
 Example butterfly: forall b u t e r f l y : nat,
   Permutation ([b;u;t;t;e;r]++[f;l;y]) ([f;l;u;t;t;e;r]++[b;y]).
 Proof.
@@ -477,7 +477,7 @@ Proof.
  (* Just to illustrate a method, let's group [u;t;t;e;r] together: *)
  change [b;u;t;t;e;r] with ([b]++[u;t;t;e;r]).
  change [f;l;u;t;t;e;r] with ([f;l]++[u;t;t;e;r]).
- remember [u;t;t;e;r] as utter. 
+ remember [u;t;t;e;r] as utter.
  clear Hequtter.
  (* Next, let's cancel [utter] from both sides.  In order to do that,
     we need to bring [utter] to the beginning of each list. *)
@@ -506,7 +506,7 @@ Search (Permutation (_::_) (_::_)).
 Qed.
 
 (** That example illustrates a general method for proving
-  permutations involving cons [::] and append [++].  
+  permutations involving cons [::] and append [++].
   You identify some portion appearing in both sides;
   you bring that portion to the front on each side using
   lemmas such as [Permutation_app_comm] and [perm_swap],
@@ -573,7 +573,7 @@ Definition first_le_second (al: list nat) : Prop :=
   end.
 
 Theorem maybe_swap_correct: forall al,
-    Permutation al (maybe_swap al) 
+    Permutation al (maybe_swap al)
     /\ first_le_second (maybe_swap al).
 Proof.
   intros.
@@ -612,7 +612,7 @@ End Exploration1.
 Theorem Forall_perm: forall {A} (f: A -> Prop) al bl,
   Permutation al bl ->
   Forall f al -> Forall f bl.
-Proof. 
+Proof.
 (* FILL IN HERE *) Admitted.
 (** [] *)
 

--- a/SF/vfa/Preface.v
+++ b/SF/vfa/Preface.v
@@ -8,7 +8,7 @@
       (the Gallina language embedded in Coq's logic).
  - Prove it correct in Coq.
  - Compile it with an optimizing ML compiler.
- 
+
  Since you want your programs to be _efficient_, you'll want to
  implement sophisticated data structures and algorithms.  Since
  Gallina is a _purely functional_ language, it helps to have
@@ -101,7 +101,7 @@
     readers.  Advanced exercises are for readers who want an extra
     challenge (and, in return, a deeper contact with the material).
 
-    _Please do not post solutions to the exercises in any public place_: 
+    _Please do not post solutions to the exercises in any public place_:
     Software Foundations is widely used both for self-study and for
     university courses.  Having solutions easily available makes it
     much less useful for courses, which typically have graded homework

--- a/SF/vfa/Priqueue.v
+++ b/SF/vfa/Priqueue.v
@@ -19,24 +19,24 @@
      uses a priority queue.
 
   We will be considering _mergeable_ priority queues, with one
-   additional operator: 
+   additional operator:
 
   - [ merge: priqueue -> priqueue -> priqueue ]
 
   The classic data structure for priority queues is the "heap", a balanced
-  binary tree in which the the key at any node is _bigger_ than all the 
+  binary tree in which the the key at any node is _bigger_ than all the
   keys in nodes below it.  With heaps, [empty] is constant time,
   [insert] and [delete_max] are logN time.  But [merge] takes NlogN
-  time, as one must take all the elements out of one queue and 
+  time, as one must take all the elements out of one queue and
   insert them into the other queue.
 
   Another way to do priority queues is by _balanced binary search trees_
   (such as red-black trees); again, [empty] is constant time,
   [insert] and [delete_max] are logN time, and [merge] takes NlogN
-  time, as one must take all the elements out of one queue and 
+  time, as one must take all the elements out of one queue and
   insert them into the other queue.
 
-  In the _Binom_ chapter we will examine an algorithm in which 
+  In the _Binom_ chapter we will examine an algorithm in which
   [empty] is constant time,  [insert], [delete_max], and [merge]
   are logN time.
 
@@ -45,8 +45,8 @@
    - [empty] takes constant time
    - [insert] takes constant time
    - [delete_max] takes linear time
-   - [merge] takes linear time 
-   
+   - [merge] takes linear time
+
 *)
 
 
@@ -75,7 +75,7 @@ Module Type PRIQUEUE.
   Parameter priq: priqueue -> Prop.
   Parameter Abs: priqueue -> list key -> Prop.
   Axiom can_relate:  forall p, priq p -> exists al, Abs p al.
-  Axiom abs_perm: forall p al bl, 
+  Axiom abs_perm: forall p al bl,
    priq p -> Abs p al -> Abs p bl -> Permutation al bl.
   Axiom  empty_priq: priq empty.
   Axiom empty_relate:  Abs empty nil.
@@ -94,14 +94,14 @@ Module Type PRIQUEUE.
    Permutation pl (k::ql) /\ Forall (ge k) ql.
   Axiom merge_priq: forall p q, priq p -> priq q -> priq (merge p q).
   Axiom merge_relate:
-    forall p q pl ql al, 
+    forall p q pl ql al,
        priq p -> priq q ->
        Abs p pl -> Abs q ql -> Abs (merge p q) al ->
        Permutation al (pl++ql).
 End PRIQUEUE.
 
 (** Take some time to consider whether this is the right specification!
-    As always, if we get the specification wrong, then proofs of 
+    As always, if we get the specification wrong, then proofs of
     "correctness" are not so useful.
 *)
 
@@ -123,19 +123,19 @@ Module List_Priqueue <: PRIQUEUE.
 (* ================================================================= *)
 (** ** Some preliminaries *)
 
-(** A copy of the [select] function from Selection.v, but 
+(** A copy of the [select] function from Selection.v, but
     getting the max element instead of the min element: *)
 
 Fixpoint select (i: nat) (l: list nat) : nat * list nat :=
 match l with
 |  nil => (i, nil)
-|  h::t => if i >=? h 
+|  h::t => if i >=? h
                then let (j, l') := select i t in (j, h::l')
                else let (j,l') := select h t in (j, i::l')
 end.
 
 (** **** Exercise: 3 stars (select_perm)  *)
-Lemma select_perm: forall i l, 
+Lemma select_perm: forall i l,
   let (j,r) := select i l in
    Permutation (i::l) (j::r).
 Proof. (* Copy your proof from Selection.v, and change one character. *)
@@ -193,7 +193,7 @@ Definition priq (p: priqueue) := True.
 
 (** The abstraction relation is trivial too. *)
 
-Inductive Abs':  priqueue -> list key -> Prop := 
+Inductive Abs':  priqueue -> list key -> Prop :=
 Abs_intro: forall p, Abs' p p.
 
 Definition Abs := Abs'.
@@ -211,7 +211,7 @@ Qed.
    to two different lists [al] and [bl], as long as one is a permutation of
    the other.  *)
 
-Lemma abs_perm: forall p al bl, 
+Lemma abs_perm: forall p al bl,
    priq p -> Abs p al -> Abs p bl -> Permutation al bl.
 Proof.
 intros.
@@ -240,7 +240,7 @@ Proof. constructor. Qed.
 
 (** **** Exercise: 2 stars (simple_priq_proofs)  *)
 Lemma delete_max_None_relate:
-  forall p, priq p -> 
+  forall p, priq p ->
       (Abs p nil <-> delete_max p = None).
 Proof.
 (* FILL IN HERE *) Admitted.
@@ -259,7 +259,7 @@ Lemma merge_priq:
 Proof. intros. constructor. Qed.
 
 Lemma merge_relate:
-    forall p q pl ql al, 
+    forall p q pl ql al,
        priq p -> priq q ->
        Abs p pl -> Abs q ql -> Abs (merge p q) al ->
        Permutation al (pl++ql).

--- a/SF/vfa/Redblack.v
+++ b/SF/vfa/Redblack.v
@@ -3,8 +3,8 @@
 (* ################################################################# *)
 (** * Required reading: *)
 
-(** 
- (1) General background on red-black trees, 
+(**
+ (1) General background on red-black trees,
    - Section 3.3 of  _Algorithms, Fourth Edition_,
        by Sedgewick and Wayne, Addison Wesley 2011;  or
    - Chapter 13 of _Introduction to Algorithms, 3rd Edition_,
@@ -12,12 +12,12 @@
    - or Wikipedia.
 
  (2) an explanation of the particular implementation we use here.
- Red-Black Trees in a Functional Setting, by Chris Okasaki. 
-_Journal of Functional Programming_, 9(4):471-477, July 1999. 
+ Red-Black Trees in a Functional Setting, by Chris Okasaki.
+_Journal of Functional Programming_, 9(4):471-477, July 1999.
  http://www.westpoint.edu/eecs/SiteAssets/SitePages/Faculty%20Publication%20Documents/Okasaki/jfp99redblack.pdf
 
  (3) Optional reading:
-  Efficient Verified Red-Black Trees, by Andrew W. Appel, September 2011. 
+  Efficient Verified Red-Black Trees, by Andrew W. Appel, September 2011.
   http://www.cs.princeton.edu/~appel/papers/redblack.pdf
 *)
 
@@ -25,13 +25,13 @@ _Journal of Functional Programming_, 9(4):471-477, July 1999.
      _balance_.   Recall that the _depth_ of a node in a tree is the
     distance from the root to that node.  The _height_ of a tree is
     the depth of the deepest node.  The [insert] or [lookup] function
-    of the BST algorithm (Chapter [SearchTree]) takes time 
+    of the BST algorithm (Chapter [SearchTree]) takes time
     proportional to the depth of the node that is found (or inserted).
     To make these functions run fast, we want trees where the
     worst-case depth (or the average depth) is as small as possible.
 
     In a perfectly balanced tree of N nodes, every node has depth less
-    than or or equal to log N, using logarithms base 2.   In an 
+    than or or equal to log N, using logarithms base 2.   In an
     approximately balanced tree, every node has depth less than or
     equal to 2 log N.  That's good enough to make [insert] and [lookup]
     run in time proportional to log N.
@@ -47,7 +47,7 @@ _Journal of Functional Programming_, 9(4):471-477, July 1999.
 
 Require Import Perm.
 Require Import Extract.
-Require Import Coq.Lists.List. 
+Require Import Coq.Lists.List.
 Export ListNotations.
 
 Definition key := int.
@@ -59,7 +59,7 @@ Variable V : Type.
 Variable default: V.
 
  Inductive tree  : Type :=
- | E : tree 
+ | E : tree
  | T: color -> tree -> key -> V -> tree -> tree.
 
  Definition empty_tree := E.
@@ -71,7 +71,7 @@ Variable default: V.
 Fixpoint lookup (x: key) (t : tree) : V :=
   match t with
   | E => default
-  | T _ tl k v tr => if ltb x k then lookup x tl 
+  | T _ tl k v tr => if ltb x k then lookup x tl
                          else if ltb k x then lookup x tr
                          else v
   end.
@@ -92,13 +92,13 @@ Fixpoint lookup (x: key) (t : tree) : V :=
 
 Definition balance rb t1 k vk t2 :=
  match rb with Red => T Red t1 k vk t2
- | _ => 
- match t1 with 
+ | _ =>
+ match t1 with
  | T Red (T Red a x vx b) y vy c =>
       T Red (T Black a x vx b) y vy (T Black c k vk t2)
  | T Red a x vx (T Red b y vy c) =>
       T Red (T Black a x vx b) y vy (T Black c k vk t2)
- | a => match t2 with 
+ | a => match t2 with
             | T Red (T Red b y vy c) z vz d =>
 	        T Red (T Black t1 k vk b) y vy (T Black c z vz d)
             | T Red b y vy (T Red c z vz d)  =>
@@ -108,14 +108,14 @@ Definition balance rb t1 k vk t2 :=
   end
  end.
 
-Definition makeBlack t := 
-  match t with 
+Definition makeBlack t :=
+  match t with
   | E => E
   | T _ a x vx b => T Black a x vx b
   end.
 
 Fixpoint ins x vx s :=
- match s with 
+ match s with
  | E => T Red E x vx E
  | T c a y vy b => if ltb x y then balance c (ins x vx a) y vy b
                         else if ltb y x then balance c a y vy (ins x vx b)
@@ -179,7 +179,7 @@ intro Hx; inversion Hx.
       [match ?c with Red => _ | Black => _  end <> _ ],
      and what it does in that case is, [destruct c] *)
 
-match goal with 
+match goal with
 | |- match ?c with Red => _ | Black => _  end <> _=> destruct c
 end.
 
@@ -189,17 +189,17 @@ end.
 
      and what it does in that case is, [destruct s] *)
 
-match goal with 
+match goal with
     | |- match ?s with E => _ | T _ _ _ _ _ => _ end  <> _=>destruct s
 end.
 
 (** Let's apply that tactic again, and then try it on the subgoals, recursively.
     Recall that the [repeat] tactical keeps trying the same tactic on subgoals. *)
 
-repeat match goal with 
+repeat match goal with
     | |- match ?s with E => _ | T _ _ _ _ _ => _ end  <> _=>destruct s
 end.
-match goal with 
+match goal with
   | |- T _ _ _ _ _ <> E => apply T_neq_E
 end.
 
@@ -217,7 +217,7 @@ unfold balance.
 (** This is the beginning of the big case analysis.  This time,
   let's combine several tactics together: *)
 
-repeat match goal with 
+repeat match goal with
   | |- (if ?x then _ else _) <> _ => destruct x
   | |- match ?c with Red => _ | Black => _  end <> _=> destruct c
   | |- match ?s with E => _ | T _ _ _ _ _ => _ end  <> _=>destruct s
@@ -250,7 +250,7 @@ unfold balance.
 (** This is the beginning of the big case analysis.  This time,
   we add one more clause to the [match goal] command: *)
 
-repeat match goal with 
+repeat match goal with
   | |- (if ?x then _ else _) <> _ => destruct x
   | |- match ?c with Red => _ | Black => _  end <> _=> destruct c
   | |- match ?s with E => _ | T _ _ _ _ _ => _ end  <> _=>destruct s
@@ -275,10 +275,10 @@ Inductive SearchTree' : Z -> tree -> Z -> Prop :=
 Inductive SearchTree: tree -> Prop :=
 | ST_intro: forall t lo hi, SearchTree' lo t hi -> SearchTree t.
 
-(** Now we prove that if [t] is a SearchTree, then the rebalanced 
-     version of [t] is also a SearchTree. *) 
+(** Now we prove that if [t] is a SearchTree, then the rebalanced
+     version of [t] is also a SearchTree. *)
 Lemma balance_SearchTree:
- forall c  s1 k kv s2 lo hi, 
+ forall c  s1 k kv s2 lo hi,
    SearchTree' lo s1 (int2Z k) ->
    SearchTree' (int2Z k + 1) s2 hi ->
    SearchTree' lo (balance c s1 k kv s2) hi.
@@ -309,7 +309,7 @@ repeat  match goal with
 
 (** There's a pattern here.  Whenever we have a hypothesis above the line
     that looks like,
-    -  H: SearchTree' _ E _    
+    -  H: SearchTree' _ E _
     -  H: SearchTree' _ (T _ _ _ _ _) _
 
    we should invert it.   Let's build that idea into our proof automation.
@@ -318,7 +318,7 @@ repeat  match goal with
 Abort.
 
 Lemma balance_SearchTree:
- forall c  s1 k kv s2 lo hi, 
+ forall c  s1 k kv s2 lo hi,
    SearchTree' lo s1 (int2Z k) ->
    SearchTree' (int2Z k + 1) s2 hi ->
    SearchTree' lo (balance c s1 k kv s2) hi.
@@ -349,7 +349,7 @@ repeat  match goal with
 Abort.
 
 Lemma balance_SearchTree:
- forall c  s1 k kv s2 lo hi, 
+ forall c  s1 k kv s2 lo hi,
    SearchTree' lo s1 (int2Z k) ->
    SearchTree' (int2Z k + 1) s2 hi ->
    SearchTree' lo (balance c s1 k kv s2) hi.
@@ -375,8 +375,8 @@ Qed.
   Copy-paste your proof of insert_SearchTree from Extract.v.
   You will need to apply [balance_SearchTree] in two places.
  *)
-Lemma ins_SearchTree: 
-   forall x vx s lo hi, 
+Lemma ins_SearchTree:
+   forall x vx s lo hi,
                     lo <= int2Z x ->
                     int2Z x < hi ->
                     SearchTree' lo s hi ->
@@ -485,7 +485,7 @@ end.
           [destruct c].
    -6. When [Abs match s with E => _ | T ... => _ end _] is below the line,
           [destruct s].
-   -7. Whenever [Abs (T _ _ _ _ _) _] is below the line, 
+   -7. Whenever [Abs (T _ _ _ _ _) _] is below the line,
                   prove it by [apply Abs_T].   This won't always work;
          Sometimes the "cts" in the proof goal does not exactly match the form
          of the "cts" required by the [Abs_T] constructor.  But it's all right if
@@ -502,7 +502,7 @@ end.
        In the first proof goal, do this: [eapply Abs_helper].
        Notice that you have two subgoals.
        The first subgoal you can prove by:
-           apply Abs_T. apply Abs_T. apply Abs_E. apply Abs_E. 
+           apply Abs_T. apply Abs_T. apply Abs_E. apply Abs_E.
            apply Abs_T. eassumption. eassumption.
        Step through that, one at a time, to see what it's doing.
        Now, undo those 7 commands, and do this instead:
@@ -511,9 +511,9 @@ end.
        Now, wrap this all up, by adding this clause to your [match goal]:
        | |- _ =>  eapply Abs_helper; [repeat econstructor; eassumption | ]
    -11.  You should still have exactly 21 subgoals, each one of the form,
-             [ t_update... = t_update... ].  Notice above the line you have some 
-           assumptions of the form,  [ H: SearchTree' lo _ hi ].  For this equality 
-         proof, we'll need to know that [lo <= hi].  So, add a clause at the end 
+             [ t_update... = t_update... ].  Notice above the line you have some
+           assumptions of the form,  [ H: SearchTree' lo _ hi ].  For this equality
+         proof, we'll need to know that [lo <= hi].  So, add a clause at the end
         of your [match goal] to apply SearchTree'_le in any such assumption,
         when below the line the proof goal is an equality [ _ = _ ].
    -12.  Still exactly 21 subgoals.  In the first subgoal, try:
@@ -527,12 +527,12 @@ end.
 
 (** Extend this list, so that the nth entry shows how many subgoals
     were remaining after you followed the nth instruction in the list above.
-    Your list should be exactly 13 elements long; there was one subgoal 
+    Your list should be exactly 13 elements long; there was one subgoal
     *before* step 1, after all. *)
 
 Definition how_many_subgoals_remaining :=
     [1; 1; 1; 1; 1; 2
- 
+
   ].
 (** [] *)
 
@@ -542,7 +542,7 @@ Theorem ins_relate:
     SearchTree t ->
     Abs t cts ->
     Abs (ins k v t) (t_update cts (int2Z k) v).
-Proof.  (* Copy your proof from SearchTree.v, and adapt it. 
+Proof.  (* Copy your proof from SearchTree.v, and adapt it.
      No need for fancy proof automation. *)
 (* FILL IN HERE *) Admitted.
 (** [] *)
@@ -597,13 +597,13 @@ Definition elements (s: tree) : list (key * V) := elements' s nil.
 
 Definition elements_property (t: tree) (cts: total_map V) : Prop :=
    forall k v,
-    (In (k,v) (elements t) -> cts (int2Z k) = v) /\ 
+    (In (k,v) (elements t) -> cts (int2Z k) = v) /\
     (cts (int2Z k) <> default -> In (k, cts (int2Z k)) (elements t)).
 
 Theorem elements_relate:
-  forall t cts,  
+  forall t cts,
   SearchTree t ->
-  Abs t cts -> 
+  Abs t cts ->
   elements_property t cts.
 Proof.
 (* FILL IN HERE *) Admitted.
@@ -626,7 +626,7 @@ Proof.
    their efficiency. *)
 
 (** **** Exercise: 4 stars (is_redblack)   *)
-(** The relation [is_redblack] ensures that there are exactly [n] black 
+(** The relation [is_redblack] ensures that there are exactly [n] black
    nodes in every path from the root to a leaf, and that there are never
    two red nodes in a row. *)
 
@@ -647,7 +647,7 @@ Proof.
 (* FILL IN HERE *) Admitted.
 
 (** [nearly_redblack] expresses, "the tree is a red-black tree, except that
-  it's nonempty and it is permitted to have two red nodes in a row at 
+  it's nonempty and it is permitted to have two red nodes in a row at
   the very root (only)."   *)
 
 Inductive nearly_redblack : tree -> nat -> Prop :=
@@ -662,7 +662,7 @@ Inductive nearly_redblack : tree -> nat -> Prop :=
 
 
 Lemma ins_is_redblack:
-  forall x vx s n, 
+  forall x vx s n,
     (is_redblack s Black n -> nearly_redblack (ins x vx s) n) /\
     (is_redblack s Red n -> is_redblack (ins x vx s) Black n).
 Proof.

--- a/SF/vfa/SearchTree.v
+++ b/SF/vfa/SearchTree.v
@@ -1,6 +1,6 @@
 (** * SearchTree: Binary search trees *)
 
-(** Binary search trees are an efficient data structure for 
+(** Binary search trees are an efficient data structure for
    lookup tables, that is, mappings from keys to values.
    The [total_map] type from Maps.v is an _inefficient_
    implementation: if you add N items to your total_map,
@@ -77,7 +77,7 @@ Proof. reflexivity.
 Qed.
 
 Goal SectionExample1.lookup = SectionExample2.lookup.
-Proof. 
+Proof.
   unfold SectionExample1.lookup, SectionExample2.lookup.
   try reflexivity. (* doesn't do anything. *)
 
@@ -112,13 +112,13 @@ Definition empty_tree : tree := E.
 Fixpoint lookup (x: key) (t : tree) : V :=
   match t with
   | E => default
-  | T tl k v tr => if x <? k then lookup x tl 
+  | T tl k v tr => if x <? k then lookup x tl
                          else if k <? x then lookup x tr
                          else v
   end.
 
 Fixpoint insert (x: key) (v: V) (s: tree) : tree :=
- match s with 
+ match s with
  | E => T E x v E
  | T a y v' b => if  x <? y then T (insert x v a) y v' b
                         else if y <? x then T a y v' (insert x v b)
@@ -206,7 +206,7 @@ Check t_apply_empty. (* : forall (A : Type) (x : id) (v : A),
            insertion or lookup will take as much as linear time.
 
 	   - SOLUTION: use an algorithm, such as "red-black trees",
-	   that ensures the trees stay balanced.  We'll do that in 
+	   that ensures the trees stay balanced.  We'll do that in
            Chapter [RedBlack].
 
      2.  Our keys are natural numbers, and Coq's [nat] type takes
@@ -262,7 +262,7 @@ Definition example_tree (v2 v4 v5 : V) :=
    T (T E 2 v2 E) 4 v4 (T E 5 v5 E).
 
 (** **** Exercise: 2 stars (example_map)  *)
-(* Fill in the definition of example_map with a total_map that 
+(* Fill in the definition of example_map with a total_map that
   you think example_tree should correspond to.  Use
   [t_update] and [(t_empty default)]. *)
 
@@ -291,7 +291,7 @@ Inductive Abs:  tree -> total_map V -> Prop :=
      If it isn't, go back and fix your definition of [example_map].
      You will probably need the [bdestruct] tactic, and [omega]. *)
 
-Lemma check_example_map: 
+Lemma check_example_map:
   forall v2 v4 v5, Abs (example_tree v2 v4 v5) (example_map v2 v4 v5).
 Proof.
 intros.
@@ -300,7 +300,7 @@ evar (m: total_map V).
 replace (example_map v2 v4 v5) with m; subst m.
 repeat constructor.
 extensionality x. destruct x as [x].
-(* HINT: 
+(* HINT:
   First,    [unfold example_map, t_update, combine, t_empty, beq_id.]
   Then, repeat the following procedure:  If you see something like
   [if 4 =? x then ... else ...],    use the tactic [bdestruct (4 =? x)].
@@ -321,9 +321,9 @@ repeat constructor.
 (change m with (example_map v2 v4 v5) in H || auto);
 (* auto; *)
 fail "Did you use copy-and-paste, from your check_example_map proof,
-       into your example_map definition?  If so, very clever. 
-       Please try it again with an example_map definition that 
-       you make up from first principles.  Or, to skip that, 
+       into your example_map definition?  If so, very clever.
+       Please try it again with an example_map definition that
+       you make up from first principles.  Or, to skip that,
        uncomment the (* auto; *) above.".
 Qed.
 
@@ -445,7 +445,7 @@ Fixpoint forall_nodes (t: tree) (P: tree->key->V->tree->Prop) : Prop :=
 
 Definition SearchTreeX (t: tree) :=
  forall_nodes t
-   (fun l k v r => 
+   (fun l k v r =>
       forall_nodes l (fun _ j _ _ => j<k) /\
       forall_nodes r (fun _ j _ _ => j>k)).
 
@@ -468,9 +468,9 @@ omega.
 Qed.
 
 Theorem elements_relate_second_attempt:
-  forall t cts,  
+  forall t cts,
   SearchTreeX t ->
-  Abs t cts -> 
+  Abs t cts ->
   list2map (elements t) = cts.
 Proof.
 
@@ -561,7 +561,7 @@ destruct H1. inv H1. omega.
 apply H; eauto.
 Qed.
 
-Lemma list2map_app_left: 
+Lemma list2map_app_left:
   forall (al bl: list (key*V)) (i: key) v,
      In (i,v) al -> list2map (al++bl) (Id i) = list2map al (Id i).
 Proof.
@@ -613,9 +613,9 @@ Qed.
 
 (* EX 3? (elements_relate) *)
 Theorem elements_relate:
-  forall t cts,  
+  forall t cts,
   SearchTree t ->
-  Abs t cts -> 
+  Abs t cts ->
   list2map (elements t) = cts.
 Proof.
 rewrite elements_slow_elements.
@@ -640,7 +640,7 @@ bdestruct (k=?i); [ omega | ].
 bdestruct (i<?k); [ | omega].
 auto.
 (* FILL IN HERE *) Admitted.
-(** [] *)   
+(** [] *)
 
 (* ################################################################# *)
 (** * Preservation of representation invariant *)
@@ -678,7 +678,7 @@ Qed.
 
 (** **** Exercise: 3 stars (insert_SearchTree)  *)
 Theorem insert_SearchTree:
-  forall k v t, 
+  forall k v t,
    SearchTree t -> SearchTree (insert k v t).
 Proof.
 clear default. (* This is here to avoid a nasty interaction between Admitted and Section/Variable *)
@@ -739,7 +739,7 @@ Print Abs.
 (** Because the [combine] function is chosen very carefully, it turns out
   that this abstraction relation even works on bogus trees! *)
 
-Remark abstraction_of_bogus_tree: 
+Remark abstraction_of_bogus_tree:
  forall v2 v3,
    Abs (T (T E 3 v3 E) 2 v2 E) (t_update (t_empty default) (Id 2) v2).
 Proof.
@@ -772,8 +772,8 @@ Qed.
   not have to care about the behavior of [lookup] (and [insert]) on
   bogus trees.  We should not need to prove anything about it, either.
 
-  Sure, it's convenient in this case that the abstraction relation is able to 
-  cope with ill-formed trees.  But in general, when proving correctness of 
+  Sure, it's convenient in this case that the abstraction relation is able to
+  cope with ill-formed trees.  But in general, when proving correctness of
   abstract-data-type (ADT) implementations, it may be a lot of extra
   effort to make the abstraction relation as heavy-duty as that.
   It's often much easier for the abstraction relation to assume that the
@@ -821,9 +821,9 @@ Definition AbsX (t: tree) (m: total_map V) : Prop :=
 (** It's easy to prove that [elements] respects this abstraction relation: *)
 
 Theorem elements_relateX:
-  forall t cts,  
+  forall t cts,
   SearchTree t ->
-  AbsX t cts -> 
+  AbsX t cts ->
   list2map (elements t) = cts.
 Proof.
 intros.
@@ -861,7 +861,7 @@ assert (~ lookup 3 bogus = m (Id 3)). {
     the bogus tree that does not satisfy the [SearchTree] property.
     [m] is the [total_map] that corresponds to the elements of [bogus].
     The [lookup] function returns [default] at key [3],
-    but the map [m] returns [v] at key [3].  And yet, assumption [H0] 
+    but the map [m] returns [v] at key [3].  And yet, assumption [H0]
     claims that they should return the same thing. *)
 apply H2.
 apply H0.
@@ -890,7 +890,7 @@ rewrite elements_slow_elements.
 (** ** Coherence with [elements] instead of [lookup] *)
 (** The first definition of the abstraction relation, [Abs], is "coherent"
      with the [lookup] operation, but not very coherent with the [elements]
-     operation.  That is, [Abs] treats all trees, including ill-formed ones, 
+     operation.  That is, [Abs] treats all trees, including ill-formed ones,
      much the way [lookup] does, so it was easy to prove [lookup_relate].
      But it was harder to prove [elements_relate].
 

--- a/SF/vfa/Selection.v
+++ b/SF/vfa/Selection.v
@@ -7,11 +7,11 @@
   quadratic-time sorting algorithm (for small input sizes) you should
   use insertion sort.  Insertion sort is simpler to implement, runs
   faster, and is simpler to prove correct.   We use selection sort here
-  only to illustrate the proof techniques.  
+  only to illustrate the proof techniques.
 
      *Well, hardly ever.  If the cost of "moving" an element is _much_
-  larger than the cost of comparing two keys, then selection sort is 
-  better than insertion sort.  But this consideration does not apply in our 
+  larger than the cost of comparing two keys, then selection sort is
+  better than insertion sort.  But this consideration does not apply in our
   setting, where the elements are  represented as pointers into the
   heap, and only the pointers need to be moved.
 
@@ -30,12 +30,12 @@ Require Import Perm.
 Fixpoint select (x: nat) (l: list nat) : nat * list nat :=
 match l with
 |  nil => (x, nil)
-|  h::t => if x <=? h 
+|  h::t => if x <=? h
                then let (j, l') := select x t in (j, h::l')
                else let (j,l') := select h t in (j, x::l')
 end.
 
-(** Now, selection-sort works by repeatedly extracting the smallest element, 
+(** Now, selection-sort works by repeatedly extracting the smallest element,
    and making a list of the results. *)
 
 (* Uncomment this function, and try it.
@@ -47,9 +47,9 @@ match l with
 end.
 *)
 
-(** _Error: Recursive call to selsort has principal argument equal 
-  to [r'] instead of [r]_.  That is, the recursion is not _structural_, since 
-  the list r' is not a structural sublist of (i::r).  One way to fix the 
+(** _Error: Recursive call to selsort has principal argument equal
+  to [r'] instead of [r]_.  That is, the recursion is not _structural_, since
+  the list r' is not a structural sublist of (i::r).  One way to fix the
   problem is to use Coq's [Function] feature, and prove that
   [length(r')<length(i::r)].  Later in this chapter, we'll show that approach.
 
@@ -96,7 +96,7 @@ Qed.
 (** Specification of correctness of a sorting algorithm:
    it rearranges the elements into a list that is totally ordered. *)
 
-Inductive sorted: list nat -> Prop := 
+Inductive sorted: list nat -> Prop :=
  | sorted_nil: sorted nil
  | sorted_1: forall i, sorted (i::nil)
  | sorted_cons: forall i j l, i <= j -> sorted (j::l) -> sorted (i::j::l).
@@ -114,7 +114,7 @@ Definition selection_sort_correct : Prop :=
 (** We'll start by working on part 1, permutations. *)
 
 (** **** Exercise: 3 stars (select_perm)  *)
-Lemma select_perm: forall x l, 
+Lemma select_perm: forall x l,
   let (y,r) := select x l in
    Permutation (x::l) (y::r).
 Proof.
@@ -130,7 +130,7 @@ induction l; intros; simpl in *.
 
 (** **** Exercise: 3 stars (selection_sort_perm)  *)
 Lemma selsort_perm:
-  forall n, 
+  forall n,
   forall l, length l = n -> Permutation l (selsort l n).
 Proof.
 
@@ -152,7 +152,7 @@ Lemma select_smallest_aux:
     select x al = (y,bl) ->
     y <= x.
 Proof.
-(* Hint: no induction needed in this lemma. 
+(* Hint: no induction needed in this lemma.
    Just use existing lemmas about select, along with [Forall_perm] *)
 (* FILL IN HERE *) Admitted.
 
@@ -170,7 +170,7 @@ destruct (select x al) eqn:?H.
 
 (** **** Exercise: 3 stars (selection_sort_sorted)  *)
 Lemma selection_sort_sorted_aux:
-  forall  y bl, 
+  forall  y bl,
    sorted (selsort bl (length bl)) ->
    Forall (fun z : nat => y <= z) bl ->
    sorted (y :: selsort bl (length bl)).
@@ -182,7 +182,7 @@ Theorem selection_sort_sorted: forall al, sorted (selection_sort al).
 Proof.
 intros.
 unfold selection_sort.
-(* Hint: do induction on the [length] of al. 
+(* Hint: do induction on the [length] of al.
     In the inductive case, use [select_smallest], [select_perm],
     and [selection_sort_sorted_aux]. *)
  (* FILL IN HERE *) Admitted.
@@ -230,7 +230,7 @@ Defined.  (* Use [Defined] instead of [Qed], otherwise you
 
 (** **** Exercise: 3 stars (selection_sort'_perm)  *)
 Lemma selsort'_perm:
-  forall n, 
+  forall n,
   forall l, length l = n -> Permutation l (selsort' l).
 Proof.
 

--- a/SF/vfa/Sort.v
+++ b/SF/vfa/Sort.v
@@ -25,9 +25,9 @@
    operating on arrays.  But it works just as well as a functional
    program operating on linked lists! *)
 
-Require Import Perm. 
+Require Import Perm.
 
-Fixpoint insert (i:nat) (l: list nat) := 
+Fixpoint insert (i:nat) (l: list nat) :=
   match l with
   | nil => i::nil
   | h::t => if i <=? h then i::h::t else h :: insert i t
@@ -69,7 +69,7 @@ Eval compute in insert 7 [1; 3; 4; 8; 12; 14; 18].
    The value Y is the number of bytes in one list node: 2 to 4 words,
    depending on how the implementation handles constructor-tags.
    We write (4-3) to indicate that four list nodes are constructed,
-   while three list nodes become eligible for garbage collection.  
+   while three list nodes become eligible for garbage collection.
 
    We will not _prove_ such things about the time and space cost, but
    they are _true_ anyway, and we should keep them in
@@ -81,7 +81,7 @@ Eval compute in insert 7 [1; 3; 4; 8; 12; 14; 18].
 (** A sorting algorithm must rearrange the elements into a list that
     is totally ordered. *)
 
-Inductive sorted: list nat -> Prop := 
+Inductive sorted: list nat -> Prop :=
 | sorted_nil:
     sorted nil
 | sorted_1: forall x,
@@ -99,7 +99,7 @@ Definition sorted' (al: list nat) :=
     Later on, we'll prove that the two definitions really are
     equivalent.  For now, let's use the first one to define what it
     means to be a correct sorting algorthm. *)
-    
+
 Definition is_a_sorting_algorithm (f: list nat -> list nat) :=
   forall al, Permutation al (f al) /\ sorted (f al).
 
@@ -113,7 +113,7 @@ Definition is_a_sorting_algorithm (f: list nat -> list nat) :=
     useful for proving [sort_perm] below.  Your proof will be by
     induction, but you'll need some of the permutation facts from the
     library, so first remind yourself by doing [SearchAbout]. *)
-  
+
 SearchAbout Permutation.
 
 Lemma insert_perm: forall x l, Permutation (x::l) (insert x l).

--- a/SF/vfa/Trie.v
+++ b/SF/vfa/Trie.v
@@ -78,12 +78,12 @@ Module VerySlow.
 Fixpoint loop (input: list nat) (c: nat) (table: total_map bool) : nat :=
   match input with
   | nil => c
-  | a::al => if table (Id a) 
+  | a::al => if table (Id a)
                   then loop al (c+1) table
                   else loop al c (t_update table (Id a) true)
  end.
 
-Definition collisions (input: list nat) : nat := 
+Definition collisions (input: list nat) : nat :=
        loop input 0 (t_empty false).
 
 Example collisions_pi: collisions [3;1;4;1;5;9;2;6] = 1.
@@ -127,8 +127,8 @@ Module Integers.
 (** We start with positive numbers. *)
 
 Inductive positive : Set :=
-  | xI : positive -> positive 
-  | xO : positive -> positive 
+  | xI : positive -> positive
+  | xO : positive -> positive
   | xH : positive.
 
 (** A positive number is either
@@ -142,7 +142,7 @@ Definition ten := xO (xI (xO xH)).
 
 (** To interpret a [positive] number as a [nat], *)
 
-Fixpoint positive2nat (p: positive) : nat := 
+Fixpoint positive2nat (p: positive) : nat :=
   match p with
   | xI q => 1 + 2 * positive2nat q
   | xO q => 0 + 2 * positive2nat q
@@ -238,7 +238,7 @@ Proof.
      But really, here you can use [omega] without penalty. *)
 
 Lemma addc_correct: forall (c: bool) (p q: positive),
-   positive2nat (addc c p q) = 
+   positive2nat (addc c p q) =
         (if c then 1 else 0) + positive2nat p + positive2nat q.
 Proof.
 (* FILL IN HERE *) Admitted.
@@ -253,13 +253,13 @@ apply addc_correct.
 Qed.
 (** [] *)
 
-(** Claim:  the [add] function on positive numbers takes worst-case time 
+(** Claim:  the [add] function on positive numbers takes worst-case time
     proportional to the log base 2 of the result.
 
     We can't prove this in Coq, since Coq has no cost model for execution.
     But we can prove it informally. Notice that [addc] is structurally recursive
    on [p], that is, the number of recursive calls is at most the height of the
-    [p] structure; that's equal to log base 2 of [p] (rounded up to the nearest 
+    [p] structure; that's equal to log base 2 of [p] (rounded up to the nearest
     integer). The last call may call [succ q], which is structurally recursive on [q],
     but this [q] argument is what remained of the original [q] after
     stripping off a number of constructors equal to the height of [p].
@@ -274,7 +274,7 @@ Inductive comparison : Set :=
     Eq : comparison | Lt : comparison | Gt : comparison.
 
 (** **** Exercise: 5 stars (compare_correct)  *)
-Fixpoint compare x y {struct x}:= 
+Fixpoint compare x y {struct x}:=
   match x, y with
     | p~1, q~1 => compare p q
     | p~1, q~0 => match compare p q with Lt => Lt | _ => Gt end
@@ -311,13 +311,13 @@ induction x; destruct y; simpl.
 (** Coq's integer type is constructed from positive numbers: *)
 
 Inductive Z : Set :=
-  | Z0 : Z 
-  | Zpos : positive -> Z 
+  | Z0 : Z
+  | Zpos : positive -> Z
   | Zneg : positive -> Z.
 
 (** We can construct efficient (logN time) algorithms for operations
    on [Z]:  [add], [subtract], [compare], and so on.  These algorithms
-   call upon the efficient algorithms for [positive]s.  
+   call upon the efficient algorithms for [positive]s.
 
    We won't show these here, because in this chapter we now turn
    to efficient maps over positive numbers. *)
@@ -330,8 +330,8 @@ End Integers.  (* Hide away our experiments with [positive] *)
 
 Print positive.  (* from the Coq standard library:
   Inductive positive : Set :=
-  |  xI : positive -> positive 
-  | xO : positive -> positive 
+  |  xI : positive -> positive
+  | xO : positive -> positive
   | xH : positive *)
 
 Check Pos.compare.  (*   : positive -> positive -> comparison *)
@@ -375,7 +375,7 @@ End RatherSlow.
 
 (** We can use balanced binary search trees (red-black trees), with
    keys of type [Z].  Then the [loop] does [N] iterations; the table lookup
-   does [O(logN)] comparisons, and each comparison takes [O(log N)] time. 
+   does [O(logN)] comparisons, and each comparison takes [O(log N)] time.
    Overall, the asymptotic run time is [N*(logN)^2]. *)
 
 (* ################################################################# *)
@@ -465,14 +465,14 @@ Definition insert {A: Type} (i: positive) (a: A) (t: trie_table A)
 Definition three_ten : trie_table bool :=
  insert 3 true (insert 10 true (empty false)).
 
-Eval compute in three_ten. 
+Eval compute in three_ten.
 (* = (false,
         Node (Node Leaf false (Node (Node Leaf true Leaf) false Leaf))
                  false
                  (Node Leaf true Leaf))
      : trie_table bool  *)
 
-Eval compute in 
+Eval compute in
    map (fun i => lookup i three_ten) [3;1;4;1;5]%positive.
 (*      = [true; false; false; false; false]  : list bool *)
 
@@ -502,7 +502,7 @@ End FastEnough.
     representation), but this evaluates in one step to [S c], which
     takes constant time, no matter how long [c] is.  In "real life", one
     might be advised to use [Z] instead of [nat] for the [c] variables,
-    in which case, [1+c] takes worst-case [log N], and average-case 
+    in which case, [1+c] takes worst-case [log N], and average-case
     constant time. *)
 
 (** **** Exercise: 2 stars (successor_of_Z_constant_time)  *)
@@ -513,22 +513,22 @@ End FastEnough.
      from 1 to N is touched exactly once -- whichever way you like. *)
 
 (* [explain here]
-*)  
+*)
 (** [] *)
 
 (* ################################################################# *)
 (** * Proving the correctness of trie tables *)
 
-(** Trie tables are just another implementation of the [Maps] 
+(** Trie tables are just another implementation of the [Maps]
      abstract data type.  What we have to prove is the same as usual for an ADT:
-     define a representation invariant, define an abstraction relation, prove 
+     define a representation invariant, define an abstraction relation, prove
      that the operations respect the invariant and the abstraction relation.
 
      We will indeed do that.  But this time we'll take a different approach.
      Instead of defining a "natural" abstraction relation based on what
      we see in the data structure, we'll define an abstraction relation
      that says, "what you get is what you get."    This will work, but it means
-     we've moved the work into directly proving some things about the 
+     we've moved the work into directly proving some things about the
      relation between the [lookup] and the [insert] operators. *)
 
 (* ================================================================= *)
@@ -551,7 +551,7 @@ Lemma look_ins_same: forall {A} a k (v:A) t, look a k (ins a k v t) = v.
 (** **** Exercise: 3 stars (look_ins_same)  *)
 (** Induction on j? Induction on t?   Do you feel lucky? *)
 
-Lemma look_ins_other: forall {A} a j k (v:A) t, 
+Lemma look_ins_other: forall {A} a j k (v:A) t,
    j <> k -> look a j (ins a k v t) = look a j t.
 (* FILL IN HERE *) Admitted.
 (** [] *)
@@ -616,13 +616,13 @@ Definition Abs {A: Type} (t: trie_table A) (m: total_map A) :=
 
 (** **** Exercise: 2 stars (is_trie)  *)
 (** If you picked a _really simple_ representation invariant, these should be easy.
-    Later, if you need to change the representation invariant in order to 
+    Later, if you need to change the representation invariant in order to
     get the [_relate] proofs to work, then you'll need to fix these proofs. *)
 
 Theorem empty_is_trie: forall {A} (default: A), is_trie (empty default).
 (* FILL IN HERE *) Admitted.
 
-Theorem insert_is_trie: forall {A} i x (t: trie_table A), 
+Theorem insert_is_trie: forall {A} i x (t: trie_table A),
    is_trie t -> is_trie (insert i x t).
 (* FILL IN HERE *) Admitted.
 (** [] *)
@@ -632,7 +632,7 @@ Theorem insert_is_trie: forall {A} i x (t: trie_table A),
     use one of the lemmas you proved above, in the section
     "Lemmas about the relation between [lookup] and [insert]." *)
 
-Theorem empty_relate: forall {A} (default: A), 
+Theorem empty_relate: forall {A} (default: A),
     Abs (empty default) (t_empty default).
 Proof.
 (* FILL IN HERE *) Admitted.
@@ -651,7 +651,7 @@ Theorem lookup_relate: forall {A} i (t: trie_table A) m,
 (** Given the abstraction relation we've chosen, this one should NOT be simple.
    However, you've already done the heavy lifting, with the lemmas
   [look_ins_same] and [look_ins_other].   You will not need induction here.
-  Instead, unfold a bunch of things, use extensionality, and get to a case analysis 
+  Instead, unfold a bunch of things, use extensionality, and get to a case analysis
   on whether [pos2nat k =? pos2nat j].   To handle that case analysis,
    use [bdestruct]. You may also need [pos2nat_injective]. *)
 
@@ -665,8 +665,8 @@ Theorem insert_relate: forall {A} k (v: A) t cts,
 (* ================================================================= *)
 (** ** Sanity check *)
 
-Example Abs_three_ten: 
-    Abs 
+Example Abs_three_ten:
+    Abs
        (insert 3 true (insert 10 true (empty false)))
        (t_update (t_update (t_empty false) (Id (pos2nat 10)) true) (Id (pos2nat 3)) true).
 Proof.
@@ -689,5 +689,5 @@ try (apply empty_relate).
   compiler (2006), and are now available in the Coq standard library as the
   [PositiveMap] module, which implements the [FMaps] interface.
   The core implementation of [PositiveMap] is just as shown in this chapter,
-  but [FMaps] uses different names for the functions [insert] and [lookup], 
+  but [FMaps] uses different names for the functions [insert] and [lookup],
   and also provides several other operations on maps.  *)

--- a/Stlc/Connect.v
+++ b/Stlc/Connect.v
@@ -90,7 +90,7 @@ Proof. (* WORKED IN CLASS *)
   default_simp.
   unfold close_exp_wrt_exp.
   default_simp.
-Qed. 
+Qed.
 (***********************************************************************)
 (** ** Connecting free variable functions.                             *)
 (***********************************************************************)
@@ -476,7 +476,7 @@ Proof.
   (* WORKED IN CLASS *)
   induction s; intros; try destruct a; default_simp.
   rewrite IHs; auto.
-Qed. 
+Qed.
 
 (***********************************************************************)
 (** * Simulation                                                       *)

--- a/Stlc/Lec1.v
+++ b/Stlc/Lec1.v
@@ -257,7 +257,7 @@ Proof.
   destruct (Y==Y).
   - auto.
   - destruct n. auto.
-Qed. 
+Qed.
 
 (** *** Exercise [subst_eq_var]
 

--- a/Stlc/Nominal.v
+++ b/Stlc/Nominal.v
@@ -190,14 +190,14 @@ Lemma fv_nom_swap : forall z y n,
 Proof.
   (* WORKED IN CLASS *)
   induction n; intros; simpl; unfold swap_var; default_simp.
-Qed. 
+Qed.
 Lemma shuffle_swap : forall w y n z,
     w <> z -> y <> z ->
     (swap w y (swap y z n)) = (swap w z (swap w y n)).
 Proof.
   (* WORKED IN CLASS *)
   induction n; intros; simpl; unfold swap_var; default_simp.
-Qed. 
+Qed.
 (*************************************************************)
 (** ** Exercises                                             *)
 (*************************************************************)

--- a/Stlc/sol/Connect_sol.v
+++ b/Stlc/sol/Connect_sol.v
@@ -90,7 +90,7 @@ Proof. (* WORKED IN CLASS *)
   default_simp.
   unfold close_exp_wrt_exp.
   default_simp.
-Qed. 
+Qed.
 (***********************************************************************)
 (** ** Connecting free variable functions.                             *)
 (***********************************************************************)
@@ -177,7 +177,7 @@ Lemma decode_lc : forall c, lc_exp (decode c).
 Proof.
   intros [[h e] s]; default_simp.
   (* SOLUTION: *)
-Qed. 
+Qed.
 (***********************************************************************)
 (** ** Properties of apply_heap *)
 (***********************************************************************)
@@ -219,7 +219,7 @@ Lemma apply_heap_open : forall h e e0,
 Proof.
 (* SOLUTION: *)
   alist induction h; intros; default_simp.
-Qed. 
+Qed.
 Hint Rewrite apply_heap_open : lngen.
 
 (** This last lemma "unsimpl"s the [apply_heap] function. *)
@@ -289,7 +289,7 @@ Proof.
   generalize 0 as k.
   generalize e. clear e.
   induction e; default_simp.
-Qed. 
+Qed.
 (** One difficulty of [swap_spec] is that we need to use the induction
     not on direct subterms, but on those that have had a swapping applied
     to them. Swapping preserves the size of a nominal term, so we can
@@ -402,7 +402,7 @@ Proof.
   - rewrite (close_exp_wrt_exp_freshen y x); auto.
     rewrite swap_spec; auto.
     congruence.
-Qed. 
+Qed.
 Lemma nom_to_exp_eq_aeq : forall n1 n2, nom_to_exp n1 = nom_to_exp n2 -> aeq n1 n2.
 Proof.
   (* SOLUTION: *)
@@ -425,7 +425,7 @@ Proof.
       rewrite <- H0.
       autorewrite with lngen.
       auto.
-Qed. 
+Qed.
 (***********************************************************************)
 (** * Scoped configurations                                            *)
 (***********************************************************************)
@@ -499,7 +499,7 @@ Proof.
     rewrite subst_exp_fresh_eq; auto.
     (* SOLUTION: *)
     rewrite scoped_get with (D2:= dom h\u D ); default_simp; eauto.
-Qed. 
+Qed.
 (***********************************************************************)
 (** ** Scoped stacks                                                    *)
 (***********************************************************************)
@@ -524,7 +524,7 @@ Proof.
   (* WORKED IN CLASS *)
   induction s; intros; try destruct a; default_simp.
   rewrite IHs; auto.
-Qed. 
+Qed.
 
 (***********************************************************************)
 (** * Simulation                                                       *)
@@ -627,7 +627,7 @@ Proof.
       simpl.
       rewrite apply_heap_app.
       auto.
-(* SOLUTION: *) Qed. 
+(* SOLUTION: *) Qed.
 (** *** Exercise [simulate_done]
 
     Show that if the machine says [Done] then the LN term is a value.
@@ -650,7 +650,7 @@ Proof. (* SOLUTION: *)
        econstructor; eauto.
   - destruct e; inversion H.
     simpl in Heqb. destruct (get x h); inversion H.
-Qed. 
+Qed.
 
 
 (** *** Challenge exercise [simulate_error]
@@ -714,7 +714,7 @@ Proof.
     rewrite apply_heap_get_none in STEP; auto.
     eapply no_step_stack with (e0 := var_f x); auto.
        intros [e0' SS]. inversion SS. eauto.
-Qed. 
+Qed.
 (***********************************************************************)
 
 (** *** Challenge exercise [machine_is_scoped]
@@ -774,4 +774,4 @@ Proof.
     auto.
     fsetdec.
     simpl. fsetdec.
-Qed. 
+Qed.

--- a/Stlc/sol/Lec1_sol.v
+++ b/Stlc/sol/Lec1_sol.v
@@ -267,7 +267,7 @@ Proof.
   destruct (Y==Y).
   - auto.
   - destruct n. auto.
-Qed. 
+Qed.
 
 (** *** Exercise [subst_eq_var]
 
@@ -286,7 +286,7 @@ Proof.
     auto.
   - Case "right".
     destruct n. auto.
-Qed. 
+Qed.
 (** *** Exercise [subst_neq_var] *)
 
 Lemma subst_neq_var : forall (x y : var) u,
@@ -301,7 +301,7 @@ Proof.
     destruct Neq. auto.
   - Case "right".
     auto.
-Qed. 
+Qed.
 (** *** Exercise [subst_same] *)
 
 Lemma subst_same : forall y e, [y ~> var_f y] e = e.
@@ -311,7 +311,7 @@ Proof.
   destruct (x == y); subst; eauto.
   rewrite IHe. auto.
   rewrite IHe1. rewrite IHe2. auto.
-Qed. 
+Qed.
 
 (*************************************************************************)
 (** ** Free variables *)
@@ -377,7 +377,7 @@ Proof.
     f_equal.
     auto.
     auto.
-Qed. 
+Qed.
 (*************************************************************************)
 (** ** Additional Exercises                                              *)
 (*************************************************************************)
@@ -435,7 +435,7 @@ Proof.
   - destruct (x0 == x).
     ++ subst. fsetdec.
     ++ simpl. auto.
-Qed. 
+Qed.
 (** *** Exercise [fv_exp_subst_exp_fresh] *)
 
 Lemma fv_exp_subst_exp_fresh :
@@ -455,7 +455,7 @@ Proof.
     fsetdec.
     fsetdec.
     fsetdec.
-Qed. 
+Qed.
 (** *** Exercise [fv_exp_subst_exp_upper] *)
 
 Lemma fv_exp_subst_exp_upper :
@@ -469,7 +469,7 @@ Proof.
   - rewrite IHe1. fsetdec.
   - rewrite IHe1_1. rewrite IHe1_2.
     fsetdec.
-Qed. 
+Qed.
 
 (*************************************************************************)
 (*************************************************************************)
@@ -576,7 +576,7 @@ Proof.
   intros x y u e Neq H.
   rewrite subst_exp_open_exp_wrt_exp with (e2 := var_f y); auto.
   rewrite subst_neq_var; auto.
-Qed.   
+Qed.
 (** *** Exercise [subst_exp_intro] *)
 
 (** This next lemma states that opening can be replaced with variable
@@ -611,7 +611,7 @@ Proof.
     f_equal.
     apply IHe1. auto.
     apply IHe2. auto.
-Qed. 
+Qed.
 
 (** *** Exercise [fv_exp_open_exp_wrt_exp_upper] *)
 
@@ -641,7 +641,7 @@ Proof.
   - rewrite IHe1. fsetdec.
   - rewrite IHe1_1. rewrite IHe1_2.
     fsetdec.
-Qed. 
+Qed.
 (*************************************************************************)
 (** ** Forall quantification in [lc_exp].                                *)
 (*************************************************************************)
@@ -790,4 +790,4 @@ Proof.
   rewrite (subst_exp_intro x).
   apply subst_exp_lc_exp; auto.
   fsetdec.
-Qed. 
+Qed.

--- a/Stlc/sol/Lec2_sol.v
+++ b/Stlc/sol/Lec2_sol.v
@@ -356,7 +356,7 @@ Proof.
     eapply typing_app.
       eapply IHtyping1. reflexivity. apply Uniq.
       eapply IHtyping2. reflexivity. apply Uniq.
-Qed. 
+Qed.
 
 (** *** Demo [typing_weakening]
 
@@ -445,7 +445,7 @@ Proof.
     apply typing_var.
       eapply uniq_remove_mid. apply J.
       eapply binds_remove_mid. apply H. apply n.
-Qed. 
+Qed.
 
 
 
@@ -504,7 +504,7 @@ Proof.
     intros F Eq. subst. simpl. eapply typing_app.
       apply IHHe1. reflexivity.
       apply IHHe2. reflexivity.
-Qed. 
+Qed.
 (** *** Exercise [typing_subst_simpl]
 
     Complete the proof of the substitution lemma stated in the form we
@@ -525,7 +525,7 @@ Proof.
   eapply typing_subst.
     simpl_env. apply H.
     apply J.
-Qed. 
+Qed.
 (*************************************************************************)
 (** * Type soundness *)
 (*************************************************************************)
@@ -594,7 +594,7 @@ Proof.
       pick fresh y for (L \u fv_exp e0).
       rewrite (subst_exp_intro y); auto.
       eapply typing_subst_simple; auto.
-Qed. 
+Qed.
 (*************************************************************************)
 (** ** Progress *)
 (*************************************************************************)
@@ -675,7 +675,7 @@ Proof.
         apply step_app.
           eapply typing_to_lc_exp; eauto.
           assumption.
-Qed. 
+Qed.
 
 (*************************************************************************)
 (** * Tactic support *)
@@ -808,7 +808,7 @@ Proof.
   intros.
   induction H; eauto.
   eapply typing_abs_exists with (x:=x); eauto.
-Qed. 
+Qed.
 (** *** Exercise [cofinite_exists] *)
 
 Lemma cofinite_exists : forall G e T,
@@ -817,7 +817,7 @@ Proof. (* SOLUTION: *)
   intros. induction H; eauto.
   pick fresh x.
   eapply typing_e_abs with (x:=x); eauto.
-Qed. 
+Qed.
 (***********************************************************************)
 (** ** Additional Exercises                                            *)
 (***********************************************************************)
@@ -847,4 +847,4 @@ Proof.
     fsetdec.
   - Case "typing_app".
     fsetdec.
-Qed. 
+Qed.

--- a/Stlc/sol/Nominal_sol.v
+++ b/Stlc/sol/Nominal_sol.v
@@ -190,14 +190,14 @@ Lemma fv_nom_swap : forall z y n,
 Proof.
   (* WORKED IN CLASS *)
   induction n; intros; simpl; unfold swap_var; default_simp.
-Qed. 
+Qed.
 Lemma shuffle_swap : forall w y n z,
     w <> z -> y <> z ->
     (swap w y (swap y z n)) = (swap w z (swap w y n)).
 Proof.
   (* WORKED IN CLASS *)
   induction n; intros; simpl; unfold swap_var; default_simp.
-Qed. 
+Qed.
 (*************************************************************)
 (** ** Exercises                                             *)
 (*************************************************************)
@@ -214,13 +214,13 @@ Lemma swap_symmetric : forall t x y,
 Proof.
   (* SOLUTION: *)
   induction t;  simpl; unfold swap_var; default_simp.
-Qed.   
+Qed.
 Lemma swap_involutive : forall t x y,
     swap x y (swap x y t) = t.
 Proof.
   (* SOLUTION: *)
   induction t;  simpl; unfold swap_var; default_simp.
-Qed.   
+Qed.
 (** *** Challenge exercise: equivariance
 
     Equivariance is the property that all functions and
@@ -233,7 +233,7 @@ Lemma swap_var_equivariance : forall v x y z w,
 Proof.
   (* SOLUTION: *)
   unfold swap_var; default_simp.
-Qed.   
+Qed.
 Lemma swap_equivariance : forall t x y z w,
     swap x y (swap z w t) = swap (swap_var x y z) (swap_var x y w) (swap x y t).
 Proof.
@@ -242,7 +242,7 @@ Proof.
   - rewrite swap_var_equivariance. auto.
   - rewrite swap_var_equivariance. rewrite IHt. auto.
   - rewrite IHt1. rewrite IHt2. auto.
-Qed. 
+Qed.
 Lemma notin_fv_nom_equivariance : forall x0 x y t ,
   x0 `notin` fv_nom t ->
   swap_var x y x0  `notin` fv_nom (swap x y t).
@@ -252,7 +252,7 @@ Proof.
   - unfold swap_var; default_simp.
   - unfold swap_var in *. default_simp.
   - destruct_notin. eauto.
-Qed. 
+Qed.
 (* HINT: For a helpful fact about sets of atoms, check AtomSetImpl.union_1 *)
 
 Lemma in_fv_nom_equivariance : forall x y x0 t,
@@ -282,7 +282,7 @@ Proof.
   - rewrite swap_equivariance in IHaeq.
     eapply aeq_abs_diff; auto.
     eapply notin_fv_nom_equivariance; auto.
-Qed. 
+Qed.
 
 
 (*************************************************************)
@@ -404,7 +404,7 @@ Proof.
   intros D t VV.
   destruct t; simpl in *; try discriminate.
   auto.
-Qed. 
+Qed.
 
 (*************************************************************)
 (** * Size based reasoning                                   *)
@@ -491,14 +491,14 @@ Lemma subst_eq_var : forall u x,
 Proof.
   (* SOLUTION: *)
   intros. unfold subst. default_simp.
-Qed. 
+Qed.
 Lemma subst_neq_var : forall u x y,
     x <> y ->
     subst u x (n_var y) = n_var y.
 Proof.
   (* SOLUTION: *)
   intros. unfold subst. default_simp.
-Qed. 
+Qed.
 Lemma subst_app : forall u x t1 t2,
     subst u x (n_app t1 t2) = n_app (subst u x t1) (subst u x t2).
 Proof. (* SOLUTION: *)
@@ -509,7 +509,7 @@ Proof. (* SOLUTION: *)
   auto.
   omega.
   omega.
-Qed. 
+Qed.
 Lemma subst_abs : forall u x y t1,
     subst u x (n_abs y t1) =
        if (x == y) then (n_abs y t1)
@@ -518,4 +518,4 @@ Lemma subst_abs : forall u x y t1,
 Proof. (* SOLUTION: *)
   intros. unfold subst. default_simp.
   rewrite swap_size_eq. auto.
-Qed. 
+Qed.

--- a/compiler/Compiler.v
+++ b/compiler/Compiler.v
@@ -150,7 +150,7 @@ Qed.
   the final state of a terminating program is unique,
   and that a program cannot both terminate and diverge,
   or terminate and go wrong, or diverge and go wrong.
-  These results follow from the generic determinism properties 
+  These results follow from the generic determinism properties
   found at the end of module [Sequence]. *)
 
 Remark stop_irred:
@@ -166,7 +166,7 @@ Proof.
   unfold mach_terminates; intros. destruct H as (pc1 & A1 & B1), H0 as (pc2 & A2 & B2).
   assert (((pc1, nil, st1) : configuration) = ((pc2, nil, st2) : configuration)).
   { eapply finseq_unique; eauto using machine_deterministic, stop_irred. }
-  congruence. 
+  congruence.
 Qed.
 
 Lemma terminates_goeswrong_exclusive:
@@ -190,7 +190,7 @@ Qed.
 Lemma goeswrong_diverges_exclusive:
   forall C st, mach_goes_wrong C st -> mach_diverges C st -> False.
 Proof.
-  unfold mach_terminates, mach_diverges; intros. 
+  unfold mach_terminates, mach_diverges; intros.
   destruct H as (pc2 & stk2 & st2 & A2 & B2 & C2).
   eapply infseq_finseq_excl with (R := transition C); eauto using machine_deterministic, stop_irred.
 Qed.
@@ -202,7 +202,7 @@ Qed.
   [ceval_step] function from the [Imp] chapter of Software Foundations,
   which provides an executable interpreter for the Imp language.
 
-  To ensure termination of the machine interpreter, we need to bound 
+  To ensure termination of the machine interpreter, we need to bound
   the number of instructions it can execute.  The result of the
   machine interpreter, therefore, is of the following type:
 *)
@@ -399,11 +399,11 @@ Lemma codeseq_at_tail:
   codeseq_at C pc (i :: C') ->
   codeseq_at C (pc + 1) C'.
 Proof.
-  intros. inversion H. 
+  intros. inversion H.
   change (C1 ++ (i :: C') ++ C3)
     with (C1 ++ (i :: nil) ++ C' ++ C3).
   rewrite <- app_ass. constructor. rewrite app_length. auto.
-Qed. 
+Qed.
 
 Lemma codeseq_at_app_left:
   forall C pc C1 C2,
@@ -458,31 +458,31 @@ Proof.
   induction a; simpl; intros.
 
 - (* ANum *)
-  apply star_one. apply trans_const. eauto with codeseq. 
+  apply star_one. apply trans_const. eauto with codeseq.
 
 - (* AId *)
-  apply star_one. apply trans_var. eauto with codeseq. 
+  apply star_one. apply trans_var. eauto with codeseq.
 
 - (* APlus *)
   eapply star_trans.
-  apply IHa1. eauto with codeseq. 
+  apply IHa1. eauto with codeseq.
   eapply star_trans.
-  apply IHa2. eauto with codeseq. 
-  apply star_one. normalize. apply trans_add. eauto with codeseq. 
+  apply IHa2. eauto with codeseq.
+  apply star_one. normalize. apply trans_add. eauto with codeseq.
 
 - (* AMinus *)
   eapply star_trans.
-  apply IHa1. eauto with codeseq. 
+  apply IHa1. eauto with codeseq.
   eapply star_trans.
-  apply IHa2. eauto with codeseq. 
-  apply star_one. normalize. apply trans_sub. eauto with codeseq. 
+  apply IHa2. eauto with codeseq.
+  apply star_one. normalize. apply trans_sub. eauto with codeseq.
 
 - (* AMult *)
   eapply star_trans.
-  apply IHa1. eauto with codeseq. 
+  apply IHa1. eauto with codeseq.
   eapply star_trans.
-  apply IHa2. eauto with codeseq. 
-  apply star_one. normalize. apply trans_mul. eauto with codeseq. 
+  apply IHa2. eauto with codeseq.
+  apply star_one. normalize. apply trans_mul. eauto with codeseq.
 Qed.
 
 (** Here is a similar proof for the compilation of boolean expressions. *)
@@ -502,7 +502,7 @@ Proof.
     apply star_one. apply trans_branch_forward with ofs. eauto with codeseq. auto.
   + (* BTrue, false *)
     repeat rewrite plus_0_r. apply star_refl.
- 
+
 - (* BFalse *)
   destruct cond; simpl.
   + (* BFalse, true *)
@@ -511,37 +511,37 @@ Proof.
     apply star_one. apply trans_branch_forward with ofs. eauto with codeseq. auto.
 
 - (* BEq *)
-  eapply star_trans. 
-  apply compile_aexp_correct with (a := a). eauto with codeseq. 
   eapply star_trans.
-  apply compile_aexp_correct with (a := a0). eauto with codeseq. 
+  apply compile_aexp_correct with (a := a). eauto with codeseq.
+  eapply star_trans.
+  apply compile_aexp_correct with (a := a0). eauto with codeseq.
   apply star_one. normalize.
   destruct cond.
   + (* BEq, true *)
     apply trans_beq with ofs. eauto with codeseq.
     destruct (beq_nat (aeval st a) (aeval st a0)); simpl; omega.
   + (* BEq, false *)
-    apply trans_bne with ofs. eauto with codeseq. 
+    apply trans_bne with ofs. eauto with codeseq.
     destruct (beq_nat (aeval st a) (aeval st a0)); simpl; omega.
 
 - (* BLe *)
-  eapply star_trans. 
-  apply compile_aexp_correct with (a := a). eauto with codeseq. 
   eapply star_trans.
-  apply compile_aexp_correct with (a := a0). eauto with codeseq. 
+  apply compile_aexp_correct with (a := a). eauto with codeseq.
+  eapply star_trans.
+  apply compile_aexp_correct with (a := a0). eauto with codeseq.
   apply star_one. normalize.
   destruct cond.
   + (* BLe, true *)
     apply trans_ble with ofs. eauto with codeseq.
     destruct (leb (aeval st a) (aeval st a0)); simpl; omega.
   + (* BLe, false *)
-    apply trans_bgt with ofs. eauto with codeseq. 
+    apply trans_bgt with ofs. eauto with codeseq.
     destruct (leb (aeval st a) (aeval st a0)); simpl; omega.
 
 - (* BNot *)
   replace (eqb (negb (beval st b)) cond)
      with (eqb (beval st b) (negb cond)).
-  apply IHb; auto. 
+  apply IHb; auto.
   destruct (beval st b); destruct cond; auto.
 
 - (* BAnd *)
@@ -554,13 +554,13 @@ Proof.
   + (* BAnd, true *)
     destruct (beval st b1); simpl.
     * (* b1 evaluates to true *)
-      normalize. apply IHb2. eauto with codeseq. 
+      normalize. apply IHb2. eauto with codeseq.
     * (* b1 evaluates to false *)
       normalize. apply star_refl.
   + (* BAnd, false *)
     destruct (beval st b1); simpl.
     * (* b1 evaluates to true *)
-      normalize. apply IHb2. eauto with codeseq. 
+      normalize. apply IHb2. eauto with codeseq.
     * (* b1 evaluates to false *)
       replace ofs' with (length code_b2 + ofs). normalize. apply star_refl.
       unfold ofs'; omega.
@@ -585,23 +585,23 @@ Proof.
 - (* := *)
   simpl in *. subst n.
   eapply star_trans. apply compile_aexp_correct. eauto with codeseq.
-  apply star_one. normalize. apply trans_setvar. eauto with codeseq. 
+  apply star_one. normalize. apply trans_setvar. eauto with codeseq.
 
 - (* sequence *)
   simpl in *.
-  eapply star_trans. apply IHceval1. eauto with codeseq. 
-  normalize. apply IHceval2. eauto with codeseq. 
+  eapply star_trans. apply IHceval1. eauto with codeseq.
+  normalize. apply IHceval2. eauto with codeseq.
 
 - (* if true *)
   simpl in *.
   set (code1 := compile_com c1) in *.
   set (codeb := compile_bexp b false (length code1 + 1)) in *.
   set (code2 := compile_com c2) in *.
-  eapply star_trans. 
+  eapply star_trans.
   apply compile_bexp_correct with (b := b) (cond := false) (ofs := length code1 + 1).
-  eauto with codeseq. 
+  eauto with codeseq.
   rewrite H. simpl. rewrite plus_0_r. fold codeb. normalize.
-  eapply star_trans. apply IHceval. eauto with codeseq. 
+  eapply star_trans. apply IHceval. eauto with codeseq.
   apply star_one. eapply trans_branch_forward. eauto with codeseq. omega.
 
 - (* if false *)
@@ -609,18 +609,18 @@ Proof.
   set (code1 := compile_com c1) in *.
   set (codeb := compile_bexp b false (length code1 + 1)) in *.
   set (code2 := compile_com c2) in *.
-  eapply star_trans. 
+  eapply star_trans.
   apply compile_bexp_correct with (b := b) (cond := false) (ofs := length code1 + 1).
-  eauto with codeseq. 
+  eauto with codeseq.
   rewrite H. simpl. fold codeb. normalize.
   replace (pc + length codeb + length code1 + S(length code2))
      with (pc + length codeb + length code1 + 1 + length code2).
-  apply IHceval. eauto with codeseq. omega. 
+  apply IHceval. eauto with codeseq. omega.
 
 - (* while false *)
-  simpl in *. 
+  simpl in *.
   eapply star_trans.
-  apply compile_bexp_correct with (b := b) (cond := false) (ofs := length (compile_com c) + 1). 
+  apply compile_bexp_correct with (b := b) (cond := false) (ofs := length (compile_com c) + 1).
   eauto with codeseq.
   rewrite H. simpl. normalize. apply star_refl.
 
@@ -628,10 +628,10 @@ Proof.
   apply star_trans with (pc, stk, st').
   simpl in *.
   eapply star_trans.
-  apply compile_bexp_correct with (b := b) (cond := false) (ofs := length (compile_com c) + 1). 
-  eauto with codeseq. 
+  apply compile_bexp_correct with (b := b) (cond := false) (ofs := length (compile_com c) + 1).
+  eauto with codeseq.
   rewrite H; simpl. rewrite plus_0_r.
-  eapply star_trans. apply IHceval1. eauto with codeseq. 
+  eapply star_trans. apply IHceval1. eauto with codeseq.
   apply star_one.
   eapply trans_branch_backward. eauto with codeseq. omega.
   apply IHceval2. auto.
@@ -645,7 +645,7 @@ Proof.
   intros. unfold compile_program. red.
   exists (length (compile_com c)); split.
   apply code_at_app. auto.
-  apply compile_com_correct_terminating with (pc := 0). auto. 
+  apply compile_com_correct_terminating with (pc := 0). auto.
   apply codeseq_at_intro with (C1 := nil). auto.
 Qed.
 
@@ -670,7 +670,7 @@ Admitted.
 (** *** Exercise (3 stars, optional) *)
 (** The manufacturer of our virtual machine offers a cheaper variant
   that lacks the [Ibge] and [Ibgt] conditional branches.  The only
-  conditional branches available are [Ibeq] (branch if equal) and 
+  conditional branches available are [Ibeq] (branch if equal) and
   [Ibne] (branch if different).  Modify the definition of [compile_bexp] and
   its correctness proof to target this cheaper virtual machine.
   Hint: study Coq's definition of subtraction between natural numbers
@@ -752,7 +752,7 @@ Inductive match_config (C: code): com * cont * state -> configuration -> Prop :=
        |                                   |
        v                                   v
     c' / k' / st' ----------------------- machstate'
-                      match_config 
+                      match_config
 >>
 Hypotheses:
 - Left: one transition in the small-step continuation semantics for Imp.
@@ -785,7 +785,7 @@ Abort.
   takes infinitely many transitions, but every such transition is matched
   by zero transitions of the virtual machine.  In this case, the source
   program diverges, but the machine code can do anything: it can diverge,
-  as expected, but it can also terminate cleanly or go wrong. 
+  as expected, but it can also terminate cleanly or go wrong.
   The simulation lemma above is too weak to rule out the last two cases!
 
   We therefore need a stronger simulation result that rules out stuttering.
@@ -794,7 +794,7 @@ Abort.
   configuration must strictly decrease.  This ensures that only a finite
   number of stuttering steps can be taken before the machine actually does
   a transition.  Here is the revised simulation diagram:
- 
+
 <<
                       match_config
      c / k / st  ----------------------- machconfig
@@ -803,7 +803,7 @@ Abort.
        |                                   |
        v                                   v
     c' / k' / st' ----------------------- machconfig'
-                      match_config 
+                      match_config
 >>
 Note the stronger conclusion on the right:
 - either the virtual machine does one or several transitions
@@ -831,7 +831,7 @@ Fixpoint com_size (c: com) : nat :=
   | WHILE b DO c1 END => com_size c1 + 1
   end.
 
-Remark com_size_nonzero: forall c, com_size c > 0. 
+Remark com_size_nonzero: forall c, com_size c > 0.
 Proof.
   induction c; simpl; omega.
 Qed.
@@ -855,10 +855,10 @@ Lemma compile_cont_Kstop_inv:
   star (transition C) (pc, nil, m) (pc', nil, m)
   /\ code_at C pc' = Some Ihalt.
 Proof.
-  intros. dependent induction H. 
+  intros. dependent induction H.
 - exists pc; split. apply star_refl. auto.
 - destruct IHcompile_cont as [pc'' [A B]]; auto.
-  exists pc''; split; auto. eapply star_step; eauto. eapply trans_branch_forward; eauto. 
+  exists pc''; split; auto. eapply star_step; eauto. eapply trans_branch_forward; eauto.
 Qed.
 
 Lemma compile_cont_Kseq_inv:
@@ -869,10 +869,10 @@ Lemma compile_cont_Kseq_inv:
   /\ codeseq_at C pc' (compile_com c)
   /\ compile_cont C k (pc' + length(compile_com c)).
 Proof.
-  intros. dependent induction H. 
-  exists pc; split. apply star_refl. split; congruence. 
+  intros. dependent induction H.
+  exists pc; split. apply star_refl. split; congruence.
   destruct (IHcompile_cont _ _ eq_refl) as [pc'' [A [B D]]].
-  exists pc''; split; auto. eapply star_step; eauto. eapply trans_branch_forward; eauto. 
+  exists pc''; split; auto. eapply star_step; eauto. eapply trans_branch_forward; eauto.
 Qed.
 
 Lemma compile_cont_Kwhile_inv:
@@ -885,10 +885,10 @@ Lemma compile_cont_Kwhile_inv:
 Proof.
   intros. dependent induction H.
 - exists (pc + 1 - ofs); split.
-  apply plus_one. eapply trans_branch_backward; eauto. 
+  apply plus_one. eapply trans_branch_backward; eauto.
   split; congruence.
 - destruct (IHcompile_cont _ _ _ (refl_equal _)) as [pc'' [A [B D]]].
-  exists pc''; split; auto. eapply plus_left. eapply trans_branch_forward; eauto. apply plus_star; auto. 
+  exists pc''; split; auto. eapply plus_left. eapply trans_branch_forward; eauto. apply plus_star; auto.
 Qed.
 
 Remark code_at_inv:
@@ -896,7 +896,7 @@ Remark code_at_inv:
 Proof.
   induction C; simpl; intros.
   inversion H.
-  destruct pc. inversion H. exists (@nil instruction); exists (i :: C); auto. 
+  destruct pc. inversion H. exists (@nil instruction); exists (i :: C); auto.
   destruct (IHC _ _ H) as [C1 [C2 [A B]]].
   exists (a :: C1); exists C2; split. simpl; congruence. simpl; congruence.
 Qed.
@@ -904,7 +904,7 @@ Qed.
 Remark code_at_codeseq:
   forall C pc i, code_at C pc = Some i -> codeseq_at C pc nil.
 Proof.
-  intros. destruct (code_at_inv _ _ _ H) as [C1 [C2 [A B]]]. 
+  intros. destruct (code_at_inv _ _ _ H) as [C1 [C2 [A B]]].
   subst. change C2 with (nil ++ C2). constructor. auto.
 Qed.
 
@@ -934,19 +934,19 @@ Lemma simulation_step:
        \/ (star (transition C) machstate1 machstate2 /\ measure impstate2 < measure impstate1))
    /\ match_config C impstate2 machstate2.
 Proof.
-  intros until machstate1; intros KSTEP MATCH. 
+  intros until machstate1; intros KSTEP MATCH.
   inversion KSTEP; clear KSTEP; subst; inversion MATCH; clear MATCH; subst; simpl in *.
 
 - (* assign *)
   econstructor; split.
-  left. eapply plus_right. eapply compile_aexp_correct; eauto with codeseq. 
-  eapply trans_setvar; eauto with codeseq. 
+  left. eapply plus_right. eapply compile_aexp_correct; eauto with codeseq.
+  eapply trans_setvar; eauto with codeseq.
   normalize. apply match_config_skip. auto.
 
 - (* seq *)
   econstructor; split.
-  right; split. apply star_refl. omega. 
-  normalize. constructor. eauto with codeseq. eapply ccont_seq; eauto with codeseq. 
+  right; split. apply star_refl. omega.
+  normalize. constructor. eauto with codeseq. eapply ccont_seq; eauto with codeseq.
 
 - (* if true *)
   set (code1 := compile_com c1) in *.
@@ -957,8 +957,8 @@ Proof.
   apply compile_bexp_correct with (b := b) (cond := false) (ofs := length code1 + 1).
   eauto with codeseq.
   omega.
-  rewrite H; simpl. fold codeb. normalize. constructor; eauto with codeseq. 
-  eapply ccont_branch; eauto with codeseq. 
+  rewrite H; simpl. fold codeb. normalize. constructor; eauto with codeseq.
+  eapply ccont_branch; eauto with codeseq.
   change (S (length code2)) with (1 + length code2) in H5. normalize. auto.
 
 - (* if false *)
@@ -970,7 +970,7 @@ Proof.
   apply compile_bexp_correct with (b := b) (cond := false) (ofs := length code1 + 1).
   eauto with codeseq.
   omega.
-  rewrite H; simpl. fold codeb. normalize. constructor; eauto with codeseq. 
+  rewrite H; simpl. fold codeb. normalize. constructor; eauto with codeseq.
   change (S (length code2)) with (1 + length code2) in H5. normalize. auto.
 
 - (* while true *)
@@ -995,21 +995,21 @@ Proof.
   right; split.
   apply compile_bexp_correct with (b := b) (cond := false) (ofs := length codec + 1).
   eauto with codeseq.
-  generalize (com_size_nonzero c). omega. 
-  rewrite H; simpl. fold codeb. normalize. apply match_config_skip. auto. 
+  generalize (com_size_nonzero c). omega.
+  rewrite H; simpl. fold codeb. normalize. apply match_config_skip. auto.
 
 - (* skip seq *)
   normalize.
   destruct (compile_cont_Kseq_inv _ _ _ _ st H4) as [pc' [X [Y Z]]].
   econstructor; split.
   right; split. eexact X. omega.
-  constructor; auto. 
+  constructor; auto.
 
 - (* skip while *)
   normalize.
   destruct (compile_cont_Kwhile_inv _ _ _ _ _ st H4) as [pc' [X [Y Z]]].
   econstructor; split.
-  left. eexact X. 
+  left. eexact X.
   constructor; auto.
 Qed.
 
@@ -1053,7 +1053,7 @@ Proof.
 - (* one or more transitions *)
   destruct (simulation _ _ _ H H1) as [S2' [P Q]].
   destruct (IHstar _ Q) as [S2'' [U V]].
-  exists S2''; split. 
+  exists S2''; split.
   eapply star_trans; eauto. destruct P. apply plus_star; auto. destruct H2; auto.
   auto.
 Qed.
@@ -1073,7 +1073,7 @@ Lemma simulation_infseq_productive:
    /\ infseq step1 S1'
    /\ match_states S1' S2'.
 Proof.
-  induction N; intros. 
+  induction N; intros.
 - (* N = 0 *)
   exfalso. omega.
 - (* N > 0 *)
@@ -1099,14 +1099,14 @@ Lemma simulation_infseq:
   match_states S1 S2 ->
   infseq step2 S2.
 Proof.
-  intros. 
+  intros.
   apply infseq_coinduction_principle_2 with
     (X := fun S2 => exists S1, infseq step1 S1 /\ match_states S1 S2).
-  intros. destruct H1 as [S [A B]]. 
-  destruct (simulation_infseq_productive (measure S + 1) S a) 
+  intros. destruct H1 as [S [A B]].
+  destruct (simulation_infseq_productive (measure S + 1) S a)
   as [S1' [S2' [P [Q R]]]].
   omega. auto. auto.
-  exists S2'; split. auto. exists S1'; auto. 
+  exists S2'; split. auto. exists S1'; auto.
   exists S1; auto.
 Qed.
 
@@ -1130,12 +1130,12 @@ Theorem compile_program_correct_terminating_2:
   mach_terminates (compile_program c) st st'.
 Proof.
   intros.
-  assert (exists machconf2, 
+  assert (exists machconf2,
            star (transition (compile_program c)) (0, nil, st) machconf2
            /\ match_config (compile_program c) (SKIP, Kstop, st') machconf2).
   eapply simulation_star; eauto. eapply simulation_step. apply match_config_initial.
-  destruct H0 as [machconf2 [STAR MS]]. 
-  inversion MS; subst. simpl in *. normalize. 
+  destruct H0 as [machconf2 [STAR MS]].
+  inversion MS; subst. simpl in *. normalize.
   destruct (compile_cont_Kstop_inv _ _ st' H5) as [pc' [A B]].
   red. exists pc'; split. auto. eapply star_trans; eauto.
 Qed.
@@ -1148,7 +1148,7 @@ Theorem compile_program_correct_diverging:
   kdiverges c st ->
   mach_diverges (compile_program c) st.
 Proof.
-  intros; red; intros. 
+  intros; red; intros.
   eapply simulation_infseq with (match_states := match_config (compile_program c)); eauto.
   eapply simulation_step. apply match_config_initial.
 Qed.
@@ -1160,13 +1160,13 @@ Qed.
   left on the stack; then [a2] is evaluated; then an [Iadd] instruction
   is performed.  For commutative operators like [+] and [*], we
   could just as well evaluate [a2] first, then [a1], then combine
-  their results.  
+  their results.
 
   This can help producing more efficient code in terms of how much
   stack space is required by the evaluation.  Consider the expression
   [1 + (2 + (3 + ... (N-1 + N)))].  With left-to-right evaluation,
   it uses [N+1] stack entries.  With right-to-left evaluation,
-  it uses only 2 stack entries.  
+  it uses only 2 stack entries.
 
   In this exercise, we explore the effect of different evaluation orders
   on stack usage.  Let us first parameterize [compile_aexp] with
@@ -1288,20 +1288,20 @@ Definition compile_aexp_optimal (a: aexp) : code :=
   will use no more stack space than evaluating [a2].  So, evaluating
   [a1 + a2] can be done with no extra space than evaluating just [a2].
   This would not be the case if we started with [a1], then evaluated [a2]:
-  in this case, one more stack slot would be needed. 
+  in this case, one more stack slot would be needed.
 
   If both arguments have the same stack needs, the two evaluation
   orders use exactly the same amount of space, so it does not matter
   which one we choose. *)
 
-(** We can show the optimality of the strategy by observing that 
+(** We can show the optimality of the strategy by observing that
   its stack usage is the minimum predicted by [stack_needs]. *)
 
 Lemma stack_usage_optimal_ord:
   forall a, stack_usage optimal_ord a = stack_needs a.
 Proof.
   (* FILL IN HERE *)
-Admitted.  
+Admitted.
 
 (** So far, we've reasoned informally on the stack usage of a particular
   evaluation strategy.  Now, let us formally connect this reasoning with the

--- a/compiler/Deadcode.v
+++ b/compiler/Deadcode.v
@@ -19,7 +19,7 @@ Module Id_Decidable <: DecidableType with Definition t := id.
   Definition eq (x y: t) := x = y.
   Lemma eq_equiv: Equivalence eq.
   Proof.
-    constructor; red; unfold eq; intros; congruence. 
+    constructor; red; unfold eq; intros; congruence.
   Qed.
   Definition eq_dec: forall (x y: t), {eq x y} + {~eq x y}.
   Proof.
@@ -102,7 +102,7 @@ Proof.
 - auto.
 - destruct (VS.subset (F t) t) eqn:SUBSET.
 + left. apply VS.subset_spec; auto.
-+ apply IHn. 
++ apply IHn.
 Qed.
 
 Hypothesis F_stable:
@@ -114,11 +114,11 @@ Proof.
   assert (forall n x, VS.Subset x default -> VS.Subset (iter n x) default).
   { induction n; intros; simpl.
   - red; auto.
-  - destruct (VS.subset (F x) x) eqn:SUBSET. 
+  - destruct (VS.subset (F x) x) eqn:SUBSET.
     + auto.
     + apply IHn; auto.
-  } 
-  unfold fixpoint. apply H. apply VSP.subset_empty. 
+  }
+  unfold fixpoint. apply H. apply VSP.subset_empty.
 Qed.
 
 End FIXPOINT.
@@ -167,8 +167,8 @@ Proof.
     (fun x : VS.t => VS.union (VS.union (fv_bexp b) L) (live c x))
           (VS.union (VS.union (fv_bexp b) (fv_com c)) L)).
   simpl in L'. fold L'. intros [A|A].
-- split. fsetdec. split; fsetdec. 
-- split. rewrite A. fsetdec. 
+- split. fsetdec. split; fsetdec.
+- split. rewrite A. fsetdec.
   split. rewrite A. fsetdec.
   eapply VSP.subset_trans. apply live_upper_bound. rewrite A. fsetdec.
 Qed.
@@ -247,10 +247,10 @@ Lemma aeval_agree:
 Proof.
   induction a; simpl; intros.
 - auto.
-- apply H. fsetdec. 
-- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec. 
+- apply H. fsetdec.
 - f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec.
-- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec. 
+- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec.
+- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec.
 Qed.
 
 Lemma beval_agree:
@@ -285,7 +285,7 @@ Lemma agree_update_dead:
   agree L s1 s2 -> ~VS.In x L ->
   agree L (t_update s1 x v) s2.
 Proof.
-  intros; red; intros. unfold t_update. destruct (beq_id x x0) eqn:BEQ. 
+  intros; red; intros. unfold t_update. destruct (beq_id x x0) eqn:BEQ.
 - apply beq_id_true_iff in BEQ. subst x0. contradiction.
 - apply H; auto.
 Qed.
@@ -316,7 +316,7 @@ Proof.
   exists st1; split. constructor. auto.
 
 - (* := *)
-  simpl in H0. destruct (VS.mem x L) eqn:LIVE_AFTER. 
+  simpl in H0. destruct (VS.mem x L) eqn:LIVE_AFTER.
   + (* x is live after *)
     assert (aeval st1 a1 = n).
     { rewrite <- H. symmetry. eapply aeval_agree. eauto. fsetdec. }
@@ -325,8 +325,8 @@ Proof.
     apply agree_update_live. eapply agree_mon. eauto. fsetdec.
   + (* x is dead after *)
     exists st1; split.
-    apply E_Skip. 
-    apply agree_update_dead. auto. 
+    apply E_Skip.
+    apply agree_update_dead. auto.
     rewrite <- VS.mem_spec. congruence.
 
 - (* seq *)
@@ -362,8 +362,8 @@ Proof.
   assert (beval st1 b = false).
   { rewrite <- H. symmetry. eapply beval_agree; eauto. }
   exists st1; split.
-  apply E_WhileFalse. auto. 
-  eapply agree_mon; eauto. 
+  apply E_WhileFalse. auto.
+  eapply agree_mon; eauto.
 
 - (* while loop *)
   destruct (live_while_charact b c L) as [P [Q R]].
@@ -372,9 +372,9 @@ Proof.
   destruct (IHceval1 (live (WHILE b DO c END) L) st1) as [st2 [E1 A1]].
     eapply agree_mon; eauto.
   destruct (IHceval2 L st2) as [st3 [E2 A2]].
-    auto. 
+    auto.
   exists st3; split.
-  apply E_WhileTrue with st2; auto. 
+  apply E_WhileTrue with st2; auto.
   auto.
 Qed.
 

--- a/compiler/Fixpoint.v
+++ b/compiler/Fixpoint.v
@@ -38,7 +38,7 @@ Hypothesis bot_smallest: forall x, le bot x.
 Variable F: A -> A.
 Hypothesis F_mon: forall x y, le x y -> le (F x) (F y).
 
-(** We iterate [F] starting from a pre-fixpoint [x]. 
+(** We iterate [F] starting from a pre-fixpoint [x].
 
 The [iterate] function takes as argument not just [x], but also two proofs:
 - that [x] is a pre-fixpoint, i.e. [le x (F x)]
@@ -49,9 +49,9 @@ Likewise, it returns as result not just the fixpoint [y], but also two proofs:
 - that [y] is below any post-fixpoint [z].
 *)
 
-Program Fixpoint iterate 
+Program Fixpoint iterate
     (x: A) (PRE: le x (F x)) (SMALL: forall z, le (F z) z -> le x z)
-    {wf gt x} 
+    {wf gt x}
     : {y : A | eq y (F y) /\ forall z, le (F z) z -> le y z } :=
   let x' := F x in
   match beq x x' with
@@ -60,14 +60,14 @@ Program Fixpoint iterate
   end.
 Next Obligation.
   split.
-  generalize (beq_correct x (F x)). rewrite <- Heq_anonymous. auto. 
+  generalize (beq_correct x (F x)). rewrite <- Heq_anonymous. auto.
   auto.
 Qed.
 Next Obligation.
-  apply le_trans with (F z); auto. 
+  apply le_trans with (F z); auto.
 Qed.
 Next Obligation.
-  red. split. auto. 
+  red. split. auto.
   generalize (beq_correct x (F x)). rewrite <- Heq_anonymous. auto.
 Qed.
 
@@ -80,7 +80,7 @@ Program Definition fixpoint : A := iterate bot _ _.
 Theorem fixpoint_correct:
   eq fixpoint (F fixpoint) /\ forall z, le (F z) z -> le fixpoint z.
 Proof.
-  unfold fixpoint. apply proj2_sig. 
+  unfold fixpoint. apply proj2_sig.
 Qed.
 
 End FIXPOINT.
@@ -165,7 +165,7 @@ Qed.
 
 Lemma vset_empty_le: forall x, vset_le vset_empty x.
 Proof.
-  unfold vset_le, vset_empty. simpl. intros. apply VSP.subset_empty. 
+  unfold vset_le, vset_empty. simpl. intros. apply VSP.subset_empty.
 Qed.
 
 (** To show that the strict order induced by [vset_eq] and [vset_le] is well-founded,
@@ -177,8 +177,8 @@ Program Definition vset_measure (x: vset) : nat := VS.cardinal (VS.diff U x).
 Lemma vset_measure_decreases:
   forall x y, vset_le x y -> ~vset_eq x y -> vset_measure y < vset_measure x.
 Proof.
-  intros. unfold vset_measure. red in H. 
-  set (X := proj1_sig x) in *. set (Y := proj1_sig y) in *. 
+  intros. unfold vset_measure. red in H.
+  set (X := proj1_sig x) in *. set (Y := proj1_sig y) in *.
   (** Find an element that is in [y] but not in [x]. *)
   destruct (VS.choose (VS.diff Y X)) as [a | ] eqn:CHOICE.
 - assert (VS.In a (VS.diff Y X)) by (apply VS.choose_spec1; auto).
@@ -189,7 +189,7 @@ Proof.
   apply VS.diff_spec. split; auto. eapply contained; eauto.
   fsetdec.
 - (** Show contradiction if no such element exists *)
-  assert (VS.Empty (VS.diff Y X)) by (apply VS.choose_spec2; auto). 
+  assert (VS.Empty (VS.diff Y X)) by (apply VS.choose_spec2; auto).
   elim H0. red. rewrite VSP.double_inclusion. split; auto.
   fold X Y. fsetdec.
 Qed.
@@ -222,15 +222,15 @@ Definition monotone (F: vset -> vset) : Prop :=
 
 Definition vset_fixpoint (F: vset -> vset) (M: monotone F) : vset :=
   fixpoint vset vset_eq vset_beq vset_beq_correct
-           vset_le vset_le_trans 
+           vset_le vset_le_trans
            vset_gt_wf vset_empty vset_empty_le F M.
 
 Lemma vset_fixpoint_correct:
-  forall F (M: monotone F), 
+  forall F (M: monotone F),
   vset_eq (vset_fixpoint F M) (F (vset_fixpoint F M))
   /\ forall z, vset_le (F z) z -> vset_le (vset_fixpoint F M) z.
 Proof.
-  intros. unfold vset_fixpoint; apply fixpoint_correct. 
+  intros. unfold vset_fixpoint; apply fixpoint_correct.
 Qed.
 
 (** Moreover, if an operator [F1] is pointwise below another operator [F2],
@@ -241,11 +241,11 @@ Lemma vset_fixpoint_le:
   (forall x, vset_le (F1 x) (F2 x)) ->
   vset_le (vset_fixpoint F1 M1) (vset_fixpoint F2 M2).
 Proof.
-  intros. 
+  intros.
   destruct (vset_fixpoint_correct F1 M1) as [EQ1 LEAST1].
   destruct (vset_fixpoint_correct F2 M2) as [EQ2 LEAST2].
   unfold vset_le, vset_eq in *.
-  apply LEAST1. 
+  apply LEAST1.
   eapply VSP.subset_trans. apply H. apply VSP.subset_equal. apply VSP.equal_sym. apply EQ2.
 Qed.
 
@@ -254,14 +254,14 @@ Qed.
 (** We redefine the abstract syntax of IMP to ensure that all
   variables mentioned in the program are taken from [U]. *)
 
-Inductive aexp : Type := 
+Inductive aexp : Type :=
   | ANum : nat -> aexp
   | AId : forall (x: id), VS.In x U -> aexp        (**r <--- NEW *)
   | APlus : aexp -> aexp -> aexp
   | AMinus : aexp -> aexp -> aexp
   | AMult : aexp -> aexp -> aexp.
 
-Inductive bexp : Type := 
+Inductive bexp : Type :=
   | BTrue : bexp
   | BFalse : bexp
   | BEq : aexp -> aexp -> bexp
@@ -287,7 +287,7 @@ Program Fixpoint fv_aexp (a: aexp) : vset :=
   | AMult a1 a2 => vset_union (fv_aexp a1) (fv_aexp a2)
   end.
 Next Obligation.
-  red; intros. apply VS.singleton_spec in H. congruence. 
+  red; intros. apply VS.singleton_spec in H. congruence.
 Qed.
 
 Fixpoint fv_bexp (b: bexp) : vset :=
@@ -336,7 +336,7 @@ Next Obligation.
   red; intros. unfold vset_le in *. set (X := proj1_sig x0) in *. set (Y := proj1_sig y) in *.
   destruct (VS.mem x X) eqn:xlive1.
 - replace (VS.mem x Y) with true.
-+ simpl. fsetdec. 
++ simpl. fsetdec.
 + symmetry; apply VS.mem_spec. apply VS.mem_spec in xlive1. fsetdec.
 - destruct (VS.mem x Y) eqn:xlive2; simpl.
 + fold X. eapply VSP.subset_trans. 2: apply VSP.union_subset_1.
@@ -348,17 +348,17 @@ Next Obligation.
 Defined.
 Next Obligation.
   red; intros. unfold vset_le, vset_union; simpl.
-  apply VSP.union_subset_5. 
-  eapply VSP.subset_trans. apply VSP.union_subset_4. apply m. eauto. 
+  apply VSP.union_subset_5.
+  eapply VSP.subset_trans. apply VSP.union_subset_4. apply m. eauto.
   apply VSP.union_subset_5. apply m0. auto.
 Defined.
 Next Obligation.
-  red; intros. unfold vset_le, vset_union; simpl. 
+  red; intros. unfold vset_le, vset_union; simpl.
   apply VSP.union_subset_5. apply m; auto.
 Defined.
 Next Obligation.
-  red; intros. apply vset_fixpoint_le. 
-  intros. unfold vset_le, vset_union; simpl. apply VSP.union_subset_4. 
+  red; intros. apply vset_fixpoint_le.
+  intros. unfold vset_le, vset_union; simpl. apply VSP.union_subset_4.
   apply VSP.union_subset_5. auto.
 Defined.
 

--- a/compiler/Regalloc.v
+++ b/compiler/Regalloc.v
@@ -105,15 +105,15 @@ Lemma aeval_agree:
 Proof.
   induction a; simpl; intros.
 - auto.
-- apply H. fsetdec. 
-- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec. 
+- apply H. fsetdec.
 - f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec.
-- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec. 
+- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec.
+- f_equal. apply IHa1. fsetdec. apply IHa2. fsetdec.
 Qed.
 
 Lemma beval_agree:
   forall L s1 s2, agree L s1 s2 ->
-  forall b, VS.Subset (fv_bexp b) L -> 
+  forall b, VS.Subset (fv_bexp b) L ->
   beval s1 b = beval s2 (rename_bexp b).
 Proof.
   induction b; simpl; intros.
@@ -132,7 +132,7 @@ Lemma agree_update_dead:
   agree L s1 s2 -> ~VS.In x L ->
   agree L (t_update s1 x v) s2.
 Proof.
-  intros; red; intros. unfold t_update. rewrite false_beq_id. auto. congruence. 
+  intros; red; intros. unfold t_update. rewrite false_beq_id. auto. congruence.
 Qed.
 
 (** Agreement is preserved by simultaneous assignment to a live variable
@@ -145,13 +145,13 @@ Lemma agree_update_live:
   (forall z, VS.In z L -> z <> x -> f z <> f x) ->
   agree L (t_update s1 x v) (t_update s2 (f x) v).
 Proof.
-  intros; red; intros. unfold t_update. destruct (beq_id x x0) eqn:E. 
+  intros; red; intros. unfold t_update. destruct (beq_id x x0) eqn:E.
 - (* x = x0 *)
   apply beq_id_true_iff in E. subst x0. rewrite <- beq_id_refl. auto.
 - (* x <> x0 *)
-  apply beq_id_false_iff in E. 
+  apply beq_id_false_iff in E.
   assert (f x0 <> f x) by (apply H0; auto).
-  rewrite false_beq_id. 
+  rewrite false_beq_id.
   apply H. apply VS.remove_spec; auto.
   auto.
 Qed.
@@ -167,23 +167,23 @@ Lemma agree_update_move:
   (forall z, VS.In z L -> z <> x -> z <> y -> f z <> f x) ->
   agree L (t_update s1 x (s1 y)) (t_update s2 (f x) (s2 (f y))).
 Proof.
-  intros; red; intros. unfold t_update. destruct (beq_id x x0) eqn:E. 
+  intros; red; intros. unfold t_update. destruct (beq_id x x0) eqn:E.
 - (* x = x0 *)
   apply beq_id_true_iff in E. subst x0. rewrite <- beq_id_refl.
-  apply H. fsetdec. 
+  apply H. fsetdec.
 - (* x <> x0 *)
-  apply beq_id_false_iff in E. 
+  apply beq_id_false_iff in E.
   destruct (beq_id x0 y) eqn:E'.
   + (* x0 = y *)
-    apply beq_id_true_iff in E'. subst x0. 
+    apply beq_id_true_iff in E'. subst x0.
     transitivity (s2 (f y)).
     apply H. fsetdec.
     destruct (beq_id (f x) (f y)); auto.
   + (* x0 <> y *)
-    apply beq_id_false_iff in E'. 
+    apply beq_id_false_iff in E'.
     assert (f x0 <> f x) by (apply H0; auto).
-    rewrite false_beq_id.  
-    apply H. fsetdec. 
+    rewrite false_beq_id.
+    apply H. fsetdec.
     auto.
 Qed.
 
@@ -200,7 +200,7 @@ Lemma agree_update_coalesced_move:
 Proof.
   intros. apply agree_extensional with (t_update s2 (f x) (s2 (f y))).
 - apply agree_update_move; auto.
-- intros. rewrite H1. unfold t_update. destruct (beq_id (f y) x0) eqn:E. 
+- intros. rewrite H1. unfold t_update. destruct (beq_id (f y) x0) eqn:E.
   + apply beq_id_true_iff in E. congruence.
   + auto.
 Qed.
@@ -220,11 +220,11 @@ Fixpoint correct_allocation (c: com) (L: VS.t) : bool :=
         match expr_is_var a with
         | Some y =>
             VS.for_all (fun z => beq_id z x || beq_id z y || negb (beq_id (f z) (f x))) L
-        | None => 
+        | None =>
             VS.for_all (fun z => beq_id z x || negb (beq_id (f z) (f x))) L
         end
       else true
-  | (c1 ;; c2) => 
+  | (c1 ;; c2) =>
       correct_allocation c1 (live c2 L) && correct_allocation c2 L
   | IFB b THEN c1 ELSE c2 FI =>
       correct_allocation c1 L && correct_allocation c2 L
@@ -237,18 +237,18 @@ Remark correct_allocation_assign_1:
   VS.for_all (fun z => beq_id z x || beq_id z y || negb (beq_id (f z) (f x))) L = true ->
   forall z, VS.In z L -> z <> x -> z <> y -> f z <> f x.
 Proof.
-  intros. 
+  intros.
   set (g := fun z => beq_id z x || beq_id z y || negb (beq_id (f z) (f x))) in *.
   assert (VS.For_all (fun x => g x = true) L).
-  { apply VS.for_all_spec. 
+  { apply VS.for_all_spec.
     red; intros. congruence.
     auto. }
-  red in H3. generalize (H3 z H0). unfold g. 
-  rewrite false_beq_id by auto. 
-  rewrite false_beq_id by auto. 
+  red in H3. generalize (H3 z H0). unfold g.
+  rewrite false_beq_id by auto.
+  rewrite false_beq_id by auto.
   simpl. destruct (beq_id (f z) (f x)) eqn:E; simpl; intros.
   congruence.
-  apply beq_id_false_iff; auto.  
+  apply beq_id_false_iff; auto.
 Qed.
 
 Remark correct_allocation_assign_2:
@@ -256,17 +256,17 @@ Remark correct_allocation_assign_2:
   VS.for_all (fun z => beq_id z x || negb (beq_id (f z) (f x))) L = true ->
   forall z, VS.In z L -> z <> x -> f z <> f x.
 Proof.
-  intros. 
+  intros.
   set (g := fun z => beq_id z x || negb (beq_id (f z) (f x))) in *.
   assert (VS.For_all (fun x => g x = true) L).
-  { apply VS.for_all_spec. 
+  { apply VS.for_all_spec.
     red; intros. congruence.
-    auto. } 
-  red in H2. generalize (H2 z H0). unfold g. 
+    auto. }
+  red in H2. generalize (H2 z H0). unfold g.
   rewrite false_beq_id by auto.
   simpl. destruct (beq_id (f z) (f x)) eqn:E; simpl; intros.
   congruence.
-  apply beq_id_false_iff; auto. 
+  apply beq_id_false_iff; auto.
 Qed.
 
 (** The proof of semantic preservation is a straightforward adaptation
@@ -287,7 +287,7 @@ Proof.
   exists st1; split. constructor. auto.
 
 - (* := *)
-  simpl in AG. destruct (VS.mem x L) eqn:is_live. 
+  simpl in AG. destruct (VS.mem x L) eqn:is_live.
   + (* x is live after *)
     assert (aeval st1 (rename_aexp a1) = n).
     { rewrite <- H. symmetry. eapply aeval_agree. eauto. fsetdec. }
@@ -296,10 +296,10 @@ Proof.
       apply expr_is_var_correct in is_var. subst a1. simpl in *.
       destruct (beq_id (f x) (f y)) eqn:coalesced.
       ** (* coalesced move *)
-         apply beq_id_true_iff in coalesced. 
+         apply beq_id_true_iff in coalesced.
          exists st1; split.
          apply E_Skip.
-         rewrite <- H. apply agree_update_coalesced_move; auto. 
+         rewrite <- H. apply agree_update_coalesced_move; auto.
          apply correct_allocation_assign_1; auto.
       ** (* preserved move *)
          exists (t_update st1 (f x) n); split.
@@ -315,12 +315,12 @@ Proof.
       apply correct_allocation_assign_2; auto.
   + (* x is dead after *)
     exists st1; split.
-    apply E_Skip. 
+    apply E_Skip.
     apply agree_update_dead. auto.
     rewrite <- VS.mem_spec. congruence.
 
 - (* seq *)
-  simpl in AG. apply andb_true_iff in CORR; destruct CORR as [CORR1 CORR2].  
+  simpl in AG. apply andb_true_iff in CORR; destruct CORR as [CORR1 CORR2].
   destruct (IHceval1 _ _ AG CORR1) as [st1' [E1 A1]].
   destruct (IHceval2 _ _ A1 CORR2) as [st2' [E2 A2]].
   exists st2'; split.
@@ -328,9 +328,9 @@ Proof.
   auto.
 
 - (* if true *)
-  simpl in AG. apply andb_true_iff in CORR; destruct CORR as [CORR1 CORR2]. 
+  simpl in AG. apply andb_true_iff in CORR; destruct CORR as [CORR1 CORR2].
   assert (beval st1 (rename_bexp b) = true).
-  { rewrite <- H. symmetry. eapply beval_agree; eauto. fsetdec. } 
+  { rewrite <- H. symmetry. eapply beval_agree; eauto. fsetdec. }
   destruct (IHceval L st1) as [st1' [E A]].
     eapply agree_mon; eauto. fsetdec.
     auto.
@@ -339,9 +339,9 @@ Proof.
   auto.
 
 - (* if false *)
-  simpl in AG. apply andb_true_iff in CORR; destruct CORR as [CORR1 CORR2]. 
+  simpl in AG. apply andb_true_iff in CORR; destruct CORR as [CORR1 CORR2].
   assert (beval st1 (rename_bexp b) = false).
-  { rewrite <- H. symmetry. eapply beval_agree; eauto. fsetdec. } 
+  { rewrite <- H. symmetry. eapply beval_agree; eauto. fsetdec. }
   destruct (IHceval L st1) as [st1' [E A]].
     eapply agree_mon; eauto. fsetdec.
     auto.
@@ -354,8 +354,8 @@ Proof.
   assert (beval st1 (rename_bexp b) = false).
   { rewrite <- H. symmetry. eapply beval_agree; eauto. }
   exists st1; split.
-  apply E_WhileFalse. auto. 
-  eapply agree_mon; eauto. 
+  apply E_WhileFalse. auto.
+  eapply agree_mon; eauto.
 
 - (* while loop *)
   destruct (live_while_charact b c L) as [P [Q R]].
@@ -365,9 +365,9 @@ Proof.
     eapply agree_mon; eauto.
     auto.
   destruct (IHceval2 L st2) as [st3 [E2 A2]].
-    auto. auto.  
+    auto. auto.
   exists st3; split.
-  apply E_WhileTrue with st2; auto. 
+  apply E_WhileTrue with st2; auto.
   auto.
 Qed.
 

--- a/compiler/Semantics.v
+++ b/compiler/Semantics.v
@@ -142,7 +142,7 @@ Admitted.
 Lemma terminates_unique:
   forall c st st1 st2, terminates c st st1 -> terminates c st st2 -> st1 = st2.
 Proof.
-  unfold terminates; intros. 
+  unfold terminates; intros.
   (* FILL IN HERE *)
 Admitted.
 
@@ -192,10 +192,10 @@ Proof.
   intros. dependent induction H.
 - apply star_refl.
 - destruct b as [c1 st1].
-  apply star_step with (c1;;c2, st1). apply CS_SeqStep. auto. auto.  
+  apply star_step with (c1;;c2, st1). apply CS_SeqStep. auto. auto.
 Qed.
 
-(** We now recall the equivalence result between 
+(** We now recall the equivalence result between
 - termination according to the big-step semantics
 - existence of a finite sequence of reductions to [SKIP]
   according to the small-step semantics.
@@ -220,12 +220,12 @@ Proof.
 - (* if false *)
   eapply star_step. apply CS_IfFalse. auto. auto.
 - (* while stop *)
-  eapply star_step. apply CS_While. 
+  eapply star_step. apply CS_While.
   apply star_one. apply CS_IfFalse. auto.
 - (* while loop *)
-  eapply star_step. apply CS_While. 
+  eapply star_step. apply CS_While.
   eapply star_step. apply CS_IfTrue. auto.
-  eapply star_trans. apply star_CS_SeqStep. apply IHceval1. 
+  eapply star_trans. apply star_CS_SeqStep. apply IHceval1.
   eapply star_step. apply CS_SeqFinish. auto.
 Qed.
 
@@ -253,12 +253,12 @@ Proof.
 - (* CS_IfFalse *)
   apply E_IfFalse; auto.
 - (* CS_While *)
-  inversion H; subst. 
+  inversion H; subst.
   + (* while loop *)
-    inversion H6; subst. 
+    inversion H6; subst.
     apply E_WhileTrue with st'; auto.
   + (* while stop *)
-    inversion H6; subst. 
+    inversion H6; subst.
     apply E_WhileFalse; auto.
 Qed.
 
@@ -374,7 +374,7 @@ Inductive kstep : (com * cont * state) -> (com * cont * state) -> Prop :=
 *)
 
 (** As in section 2, we can define the behavior of a command in terms of
-  sequences of [kstep] reductions.  
+  sequences of [kstep] reductions.
   Initial configurations are of the form (whole-command, [Kstop], initial-state).
   Final configurations are ([SKIP], [Kstop], final-state).  *)
 
@@ -407,7 +407,7 @@ Definition kdiverges (c: com) (st: state) : Prop :=
 **)
 
 (** If you're curious about adding "break" to the big-step semantics of
-  section 1, see exercise [BreakImp] in the [Imp] module of 
+  section 1, see exercise [BreakImp] in the [Imp] module of
   Software Foundations. *)
 
 (** *** Exercise (2 stars, recommended) *)
@@ -443,9 +443,9 @@ Proof.
 - (* x := a1 *)
   apply star_one. apply KS_Ass. auto.
 - (* sequence *)
-  eapply star_step. apply KS_Seq. 
-  eapply star_trans. apply IHceval1. 
-  eapply star_step. apply KS_SkipSeq. 
+  eapply star_step. apply KS_Seq.
+  eapply star_trans. apply IHceval1.
+  eapply star_step. apply KS_SkipSeq.
   apply IHceval2.
 - (* if true *)
   eapply star_step. apply KS_IfTrue. auto. auto.
@@ -454,14 +454,14 @@ Proof.
 - (* while stop *)
   apply star_one. apply KS_WhileFalse. auto.
 - (* while loop *)
-  eapply star_step. apply KS_WhileTrue. auto. 
-  eapply star_trans. apply IHceval1. 
-  eapply star_step. apply KS_SkipWhile. 
+  eapply star_step. apply KS_WhileTrue. auto.
+  eapply star_trans. apply IHceval1.
+  eapply star_step. apply KS_SkipWhile.
   apply IHceval2.
 Qed.
 
 (** For the reverse implication, we adapt lemma [cstep_append_ceval] to show
-  that one step of reduction [kstep (c1, k1, st1) (c2, k2, st2)] 
+  that one step of reduction [kstep (c1, k1, st1) (c2, k2, st2)]
   followed by big-step evaluation of [(c2, k2, st2)] is equivalent to
   big-step evaluation of [(c1, k1, st1)].  However, we now need to define
   big-step evaluation of a pair [(c, k)] of a subcommand and a continuation.
@@ -503,14 +503,14 @@ Proof.
 - (* KS_WhileTrue *)
   inversion H0; subst. inversion H2; subst. econstructor. eapply E_WhileTrue; eauto. auto.
 - (* KS_WhileFalse *)
-  inversion H0; subst. inversion H1; subst. econstructor. apply E_WhileFalse; auto. auto. 
+  inversion H0; subst. inversion H1; subst. econstructor. apply E_WhileFalse; auto. auto.
 - (* KS_SkipSeq *)
   inversion H; subst. econstructor. apply E_Skip. eapply KE_seq; eauto.
 - (* KS_SkipWhile *)
   inversion H; subst. econstructor. apply E_Skip. eapply KE_while; eauto.
 Qed.
 
-(** We can, then, extend this result to sequences of [kstep] transitions, 
+(** We can, then, extend this result to sequences of [kstep] transitions,
   and conclude. *)
 
 Lemma ksteps_append_ckeval:
@@ -520,15 +520,15 @@ Lemma ksteps_append_ckeval:
   ckeval c1 k1 st1 st3.
 Proof.
   intros. dependent induction H.
-- auto. 
-- destruct b as [[c' k'] st']. eapply kstep_append_ckeval; eauto. 
+- auto.
+- destruct b as [[c' k'] st']. eapply kstep_append_ckeval; eauto.
 Qed.
 
 Theorem kterminates_to_ceval:
   forall c st st',
   kterminates c st st' -> c / st \\ st'.
 Proof.
-  unfold kterminates; intros. 
+  unfold kterminates; intros.
   assert (CKEV: ckeval c Kstop st st').
   { eapply ksteps_append_ckeval; eauto.
     econstructor. apply E_Skip. apply KE_stop. }
@@ -584,20 +584,20 @@ Proof.
   do 3 econstructor; split. apply plus_one. apply cstep_apply_cont. apply CS_Ass. reflexivity. auto.
 - (* seq *)
   inversion H0; clear H0; subst.
-  change (apply_cont k (c1;;c2)) with (apply_cont (Kseq c2 k) c1). 
-  eapply IHc1; eauto. 
+  change (apply_cont k (c1;;c2)) with (apply_cont (Kseq c2 k) c1).
+  eapply IHc1; eauto.
 - (* if *)
   inversion H0; clear H0; subst.
-+ (* if true *) 
++ (* if true *)
   do 3 econstructor; split. apply plus_one. apply cstep_apply_cont. apply CS_IfTrue; auto. auto.
-+ (* if false *) 
++ (* if false *)
   do 3 econstructor; split. apply plus_one. apply cstep_apply_cont. apply CS_IfFalse; auto. auto.
 - (* while *)
   inversion H0; clear H0; subst.
 + (* while true *)
   exists c; exists (Kwhile b c k); exists st; split.
-  simpl. eapply plus_left. apply cstep_apply_cont. apply CS_While. 
-  apply star_one. apply cstep_apply_cont. apply CS_IfTrue; auto. 
+  simpl. eapply plus_left. apply cstep_apply_cont. apply CS_While.
+  apply star_one. apply cstep_apply_cont. apply CS_IfTrue; auto.
   auto.
 + (* while false *)
   do 3 econstructor; split.
@@ -624,7 +624,7 @@ Lemma invert_cstep_apply_cont:
   cstep (apply_cont k c, st) (c', st') ->
   cstep_apply_cont_cases k c st c' st'.
 Proof.
-  induction k; simpl; intros. 
+  induction k; simpl; intros.
 - (* Kstop *)
   change c' with (apply_cont Kstop c'). apply cacc_base; auto.
 - (* Kseq *)
@@ -632,7 +632,7 @@ Proof.
   + (* base *)
     inversion H0; clear H0; subst.
     * (* seq step *)
-      change (apply_cont k (c1';;c)) with (apply_cont (Kseq c k) c1'). 
+      change (apply_cont k (c1';;c)) with (apply_cont (Kseq c k) c1').
       apply cacc_base; auto.
     * (* seq finish *)
       apply cacc_skip_seq.
@@ -641,7 +641,7 @@ Proof.
   + (* base *)
     inversion H0; clear H0; subst.
     * (* seq step *)
-      change (apply_cont k (c1';;WHILE b DO c END)) with (apply_cont (Kwhile b c k) c1'). 
+      change (apply_cont k (c1';;WHILE b DO c END)) with (apply_cont (Kwhile b c k) c1').
       apply cacc_base; auto.
     * (* seq finish *)
       apply cacc_skip_while.
@@ -664,17 +664,17 @@ Proof.
     destruct (IHcstep _ _ _ _ eq_refl eq_refl (Kseq c0 k) H1)
     as [c'' [k'' [st'' [A B]]]].
     exists c''; exists k''; exists st''; split; auto.
-    eapply plus_left. apply KS_Seq. apply plus_star. auto. 
+    eapply plus_left. apply KS_Seq. apply plus_star. auto.
   + (* seq finish *)
     do 3 econstructor; split.
-    eapply plus_left. apply KS_Seq. apply star_one. apply KS_SkipSeq. 
+    eapply plus_left. apply KS_Seq. apply star_one. apply KS_SkipSeq.
     auto.
   + (* if true *)
     do 3 econstructor; split. apply plus_one. apply KS_IfTrue. auto. auto.
   + (* if false *)
     do 3 econstructor; split. apply plus_one. apply KS_IfFalse. auto. auto.
   + (* while *)
-    inversion H1; clear H1; subst. destruct b0 as [c'' st'']. 
+    inversion H1; clear H1; subst. destruct b0 as [c'' st''].
     specialize (invert_cstep_apply_cont _ _ _ _ _ H). intros CASES; inversion CASES; clear CASES; subst.
     inversion H1; clear H1; subst.
     * (* while true *)
@@ -695,22 +695,22 @@ Theorem kdiverges_iff_diverges:
 Proof.
   intros; split; intros.
 - (* kdiverges -> diverges *)
-  unfold diverges. 
+  unfold diverges.
   apply infseq_coinduction_principle_2 with
     (X := fun c_st => exists c, exists k, exists st,
                       c_st = (apply_cont k c, st) /\ infseq kstep (c, k, st)).
   intros. destruct H0 as [c1 [k1 [st1 [EQ ISEQ]]]].
-  destruct (kinfseq_cinfseq _ _ _ ISEQ) as [c2 [k2 [st2 [CSTEPS ISEQ']]]]. 
+  destruct (kinfseq_cinfseq _ _ _ ISEQ) as [c2 [k2 [st2 [CSTEPS ISEQ']]]].
   exists (apply_cont k2 c2, st2); split.
   subst a; auto.
   exists c2; exists k2; exists st2; auto.
   exists c; exists Kstop; exists st; auto.
 - (* diverges -> kdiverges *)
-  unfold kdiverges. 
+  unfold kdiverges.
   apply infseq_coinduction_principle_2 with
     (X := fun c_k_st =>
             match c_k_st with (c, k, st) => infseq cstep (apply_cont k c, st) end).
-  intros [[c1 k1] st1] ISEQ. 
+  intros [[c1 k1] st1] ISEQ.
   destruct (cinfseq_kinfseq _ _ _ ISEQ) as [c2 [k2 [st2 [KSTEPS ISEQ']]]].
   exists (c2, k2, st2); auto.
   auto.

--- a/compiler/Sequences.v
+++ b/compiler/Sequences.v
@@ -27,7 +27,7 @@ Qed.
 Lemma star_trans:
   forall (a b: A), star a b -> forall c, star b c -> star a c.
 Proof.
-  induction 1; eauto using star. 
+  induction 1; eauto using star.
 Qed.
 
 (** One or several transitions: transitive closure of [R]. *)
@@ -39,14 +39,14 @@ Inductive plus: A -> A -> Prop :=
 Lemma plus_one:
   forall a b, R a b -> plus a b.
 Proof.
-  eauto using star, plus. 
+  eauto using star, plus.
 Qed.
 
 Lemma plus_star:
   forall a b,
   plus a b -> star a b.
 Proof.
-  intros. inversion H. eauto using star.  
+  intros. inversion H. eauto using star.
 Qed.
 
 Lemma plus_star_trans:
@@ -80,12 +80,12 @@ Definition all_seq_inf (a: A) : Prop :=
   from [a], there exists one infinite sequence of transitions
   [a --> a1 --> a2 --> ... -> aN -> ...].
 
-  Indeed, consider [A = nat] and [R] such that [R 0 0] and [R 0 1].  
+  Indeed, consider [A = nat] and [R] such that [R 0 0] and [R 0 1].
   [all_seq_inf 0] does not hold, because a sequence [0 -->* 1] cannot be extended.
-  Yet, [R] admits an infinite sequence, namely [0 --> 0 --> ...].  
+  Yet, [R] admits an infinite sequence, namely [0 --> 0 --> ...].
 
-  Another attempt would be to represent the sequence of states 
-  [a0 --> a1 --> a2 --> ... -> aN -> ...] explicitly, as a function 
+  Another attempt would be to represent the sequence of states
+  [a0 --> a1 --> a2 --> ... -> aN -> ...] explicitly, as a function
   [f: nat -> A] such that [f i] is the [i]-th state [ai] of the sequence. *)
 
 Definition infseq_with_function (a: A) : Prop :=
@@ -117,7 +117,7 @@ CoInductive infseq: A -> Prop :=
 
   The [infseq] predicate above must be defined coinductively.  Indeed, if
   we define it inductively, the predicate would be empty (always false),
-  since there are no base cases!  
+  since there are no base cases!
 
   Coq provides some primitive support for constructing infinite derivations
   of facts such as [infseq a].  Such constructions are proofs by coinduction.
@@ -130,7 +130,7 @@ Proof.
 Qed.
 
 (** This style of proof by coinduction, using the [cofix] tactic, is effective
-  but can run into limitations of Coq's proof engine (the so-called 
+  but can run into limitations of Coq's proof engine (the so-called
   "guard condition").  However, we can derive more conventional
   coinduction principles that are often easier to use. *)
 
@@ -147,7 +147,7 @@ Lemma infseq_coinduction_principle:
   forall a, X a -> infseq a.
 Proof.
   intros X P. cofix COINDHYP; intros.
-  destruct (P a H) as [b [U V]]. apply infseq_step with b; auto. 
+  destruct (P a H) as [b [U V]]. apply infseq_step with b; auto.
 Qed.
 
 (** An even more useful variant of this coinduction principle considers a
@@ -162,10 +162,10 @@ Proof.
   intros.
   apply infseq_coinduction_principle with
     (X := fun a => exists b, star a b /\ X b).
-- intros. 
+- intros.
   destruct H1 as [b [STAR Xb]]. inversion STAR; subst.
 + destruct (H b Xb) as [c [PLUS Xc]]. inversion PLUS; subst.
-  exists b0; split. auto. exists c; auto. 
+  exists b0; split. auto. exists c; auto.
 + exists b0; split. auto. exists b; auto.
 - exists a; split. apply star_refl. auto.
 Qed.
@@ -178,8 +178,8 @@ Lemma infseq_if_all_seq_inf:
   forall a, all_seq_inf a -> infseq a.
 Proof.
   apply infseq_coinduction_principle.
-  intros. destruct (H a) as [b Rb]. constructor. 
-  exists b; split; auto. 
+  intros. destruct (H a) as [b Rb]. constructor.
+  exists b; split; auto.
   unfold all_seq_inf; intros. apply H. apply star_step with b; auto.
 Qed.
 
@@ -192,14 +192,14 @@ Proof.
   apply infseq_coinduction_principle.
   intros. destruct H as [f [P Q]].
   exists (f 1); split.
-  subst a. apply Q. 
+  subst a. apply Q.
   exists (fun n => f (1 + n)); split. auto. intros. apply Q.
 Qed.
- 
+
 (** Consider the transition sequences starting at state [a].
   They can be infinite, or they can be finite: after a number of transitions,
   we reach a state from with no transition is possible.  It is intuitively
-  obvious that at least one of the two cases must hold. 
+  obvious that at least one of the two cases must hold.
 
   It is however impossible to prove this fact in Coq's constructive logic.
   Indeed, a constructive proof would be isomorphic (by the Curry-Howard isomorphism)
@@ -243,8 +243,8 @@ Proof.
   induction 1; intros.
 - auto.
 - inversion H1; subst.
-+ right. eauto using star. 
-+ assert (b = b0) by (eapply R_functional; eauto). subst b0. 
++ right. eauto using star.
++ assert (b = b0) by (eapply R_functional; eauto). subst b0.
   apply IHstar; auto.
 Qed.
 
@@ -265,7 +265,7 @@ Lemma infseq_star_inv:
   forall a b, star a b -> infseq a -> infseq b.
 Proof.
   induction 1; intros.
-- auto. 
+- auto.
 - inversion H1; subst.
   assert (b = b0) by (eapply R_functional; eauto). subst b0.
   apply IHstar; auto.
@@ -275,9 +275,9 @@ Lemma infseq_finseq_excl:
   forall a b,
   star a b -> irred b -> infseq a -> False.
 Proof.
-  intros. 
-  assert (infseq b) by (eapply infseq_star_inv; eauto). 
-  inversion H2. elim (H0 b0); auto. 
+  intros.
+  assert (infseq b) by (eapply infseq_star_inv; eauto).
+  inversion H2. elim (H0 b0); auto.
 Qed.
 
 (** If there exists an infinite sequence of transitions from [a],
@@ -286,14 +286,14 @@ Qed.
 Lemma infseq_all_seq_inf:
   forall a, infseq a -> all_seq_inf a.
 Proof.
-  intros. unfold all_seq_inf. intros. 
-  assert (infseq b) by (eapply infseq_star_inv; eauto). 
+  intros. unfold all_seq_inf. intros.
+  assert (infseq b) by (eapply infseq_star_inv; eauto).
   inversion H1. subst. exists b0; auto.
 Qed.
 
 End SEQUENCES.
 
 
-  
+
 
 

--- a/qc/Atom.v
+++ b/qc/Atom.v
@@ -6,8 +6,8 @@
 
 
 
-(** This file defines a type of atoms with: 
-      - a _decidable equality_ 
+(** This file defines a type of atoms with:
+      - a _decidable equality_
       - a way of generating _fresh_ atoms
 *)
 
@@ -39,7 +39,7 @@ Module Atom : ATOM.
 
   Definition t := nat.
   Definition eq_dec := eq_nat_dec.
-  
+
   Fixpoint max_elt (al:list t) : t :=
     match al with
       | nil => 0
@@ -56,8 +56,8 @@ Module Atom : ATOM.
       inversion H; subst; simpl. apply Nat.le_max_l.
       eapply le_trans; auto with arith. (* apply Nat.le_max_r. *)
   Qed.
-    
-  Lemma fresh_not_in : forall l, 
+
+  Lemma fresh_not_in : forall l,
     ~ In (fresh l) l.
   Proof.
     unfold fresh, not. intros l Hin.
@@ -68,7 +68,7 @@ Module Atom : ATOM.
   Include HasUsualEq <+ UsualIsEq.
 
   Definition nat_of (a : nat) := a.
-  
+
 End Atom.
 
 (* Automatically unfold Atom.eq *)

--- a/qc/Introduction.v
+++ b/qc/Introduction.v
@@ -1,7 +1,7 @@
 (** * Introduction *)
 
 (**  Can we trim the import list (perhaps adding some thing to
-   QuickChick.v)? 
+   QuickChick.v)?
  *)
 Set Warnings "-extraction-opaque-accessed,-extraction".
 Set Warnings "-notation-overridden,-parsing".
@@ -48,10 +48,10 @@ Conjecture removeP : forall x l,  ~ (In x (remove x l)).
 
 QuickChick removeP.
 
-(** The [QuickChick] command takes a property (which must be 
-    "executable" -- we'll see later exactly what this means) and 
-    attempts to falsify it by running it on many randomly 
-    generated inputs, resulting in output like this: 
+(** The [QuickChick] command takes a property (which must be
+    "executable" -- we'll see later exactly what this means) and
+    attempts to falsify it by running it on many randomly
+    generated inputs, resulting in output like this:
 
     0
     [0, 0]
@@ -112,7 +112,7 @@ Fixpoint insert x l :=
     _typeclasses_, which QuickChick uses extensively both internally
     and in its programmatic interface to users.  This is
     [Typeclasses].
-    
+
     Next ([QC]) we'll cover the core concepts and features of
     QuickChick itself.
 
@@ -123,4 +123,3 @@ Fixpoint insert x l :=
     compiler appears as the [CompilerTest] chapter of the [vminus]
     volume. *)
 
-       

--- a/qc/Maps.v
+++ b/qc/Maps.v
@@ -32,7 +32,7 @@ Axiom update_neq : forall v k1 k2 m, k2 <> k1 -> get (set m k1 v) k2 = get m k2.
 Axiom get_in_dom : forall m k v, get m k = Some v -> In k (dom m).
 Axiom dom_in_get : forall m k, In k (dom m) -> exists v, get m k = Some v.
 Axiom get_forallb2 : forall m f,
-                       (forall k v, get m k = Some v -> f k v = true) 
+                       (forall k v, get m k = Some v -> f k v = true)
                        <-> forallb2 f m = true.
 End withv.
 
@@ -48,7 +48,7 @@ Definition t := list (K.t * V).
 
 Definition empty : t := [].
 
-Fixpoint get m k : option V := 
+Fixpoint get m k : option V :=
   match m with
     | [] => None
     | (k', v) :: m' => if K.eq_dec k k'
@@ -81,7 +81,7 @@ Fixpoint forallb2' (f:K.t -> V -> bool) (m:t) (d:list K.t) : bool :=
                       | None => false
                       | Some v => f k v && forallb2' f m d'
                     end
-     end.  
+     end.
 
 Definition forallb2 (f:K.t -> V -> bool) (m:t) : bool :=
   forallb2' f m (dom m).
@@ -105,14 +105,14 @@ Lemma get_in_dom : forall m k v,
   get m k = Some v -> In k (dom m).
 Proof.
   induction m; intros k v. inversion 1.
-  destruct a as [k' v']; simpl in *. intros. destruct (K.eq_dec k k'); intuition eauto. 
+  destruct a as [k' v']; simpl in *. intros. destruct (K.eq_dec k k'); intuition eauto.
 Qed.
 
 Lemma dom_in_get : forall m k,
   In k (dom m) -> exists v, get m k = Some v.
 Proof.
   induction m. inversion 1.
-  destruct a as [k' v']; simpl in *. 
+  destruct a as [k' v']; simpl in *.
   intro k. destruct (K.eq_dec k k') as [|Heq]; intros. intuition eauto.
   inversion H; eauto; contradict Heq; auto.
 Qed.
@@ -129,13 +129,13 @@ Proof.
   pose proof (dom_in_get m) as Hd.
   set (d := dom m) in *. clearbody d.
 
-  induction d. reflexivity. simpl. 
+  induction d. reflexivity. simpl.
   destruct (get m a) eqn:Hget.
   rewrite IHd; auto. assert (f a v = true).
   apply Hpf. eapply H; eauto. rewrite H0. simpl. reflexivity.
   intros. apply Hd. simpl. right. auto.
-  
-  ecase (Hd a) as [v Hv]; try (left; auto). 
+
+  ecase (Hd a) as [v Hv]; try (left; auto).
   rewrite Hv in Hget. inversion Hget.
 
   - (* Case "<-". *)
@@ -145,17 +145,17 @@ Proof.
   induction d. inversion Hd.
   simpl in H.
   destruct (K.eq_dec a k). subst a. rewrite H0 in H.
-  apply Hpf; auto. destruct (f k v); auto. 
+  apply Hpf; auto. destruct (f k v); auto.
   apply IHd. destruct (get m a); try solve [inversion H].
   destruct (f a v0).
   destruct (forallb2' f m d); auto.
   destruct (forallb2' f m d); auto.
   inversion Hd; intuition.
-Qed.  
+Qed.
 
 Lemma get_forallb2 : forall m f,
-  (forall k v, get m k = Some v -> f k v = true) 
-  <-> 
+  (forall k v, get m k = Some v -> f k v = true)
+  <->
   forallb2 f m = true.
 Proof.
   intros. unfold forallb2.
@@ -165,12 +165,12 @@ Proof.
   pose proof (dom_in_get m) as Hd.
   set (d := dom m) in *. clearbody d.
 
-  induction d. reflexivity. simpl. 
+  induction d. reflexivity. simpl.
   destruct (get m a) eqn:Hget.
   rewrite H; auto. rewrite IHd; auto. intros.
   apply Hd. simpl. right; auto.
-  
-  ecase (Hd a) as [v Hv]; try (left; auto). 
+
+  ecase (Hd a) as [v Hv]; try (left; auto).
   rewrite Hv in Hget. inversion Hget.
 
   - (* Case "<-". *)
@@ -186,7 +186,7 @@ Proof.
   destruct (forallb2' f m d); auto.
   destruct (f a v0); auto.
   inversion Hd; intuition.
-Qed.  
+Qed.
 
 End withv.
 

--- a/qc/QC.v
+++ b/qc/QC.v
@@ -39,17 +39,17 @@ Local Open Scope string.
     a generator that always returns this value. *)
 
 Check returnGen.
-(**  
-     ===> 
-       returnGen : ?A -> G ?A 
+(**
+     ===>
+       returnGen : ?A -> G ?A
 *)
 
 (** We can see how it behaves by using the [Sample] command: *)
 
 Sample (returnGen 42).
-(** 
+(**
      ===>
-         [42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42] 
+         [42, 42, 42, 42, 42, 42, 42, 42, 42, 42, 42]
 *)
 
 (** Next, given a random generator for [A] and a _function_ [f] taking
@@ -58,10 +58,10 @@ Sample (returnGen 42).
     internally generating a random [A] and applying [f] to it. *)
 
 Check bindGen.
-(** 
-     ===> 
-        bindGen : G ?A -> (?A -> G ?B) -> G ?B 
-*) 
+(**
+     ===>
+        bindGen : G ?A -> (?A -> G ?B) -> G ?B
+*)
 
 (** With these two primitives in hand, we can make [G] an instance of
     the [Monad] typeclass.  (This [Instance] should really be defined
@@ -80,13 +80,13 @@ Instance gMonad : `{Monad G} | 3 :=
     natural numbers and integers. They are accessed via the [choose]
     combinator. *)
 
-Print ChoosableFromInterval. 
+Print ChoosableFromInterval.
 
 Check @choose.
-(** 
-     ===> 
+(**
+     ===>
         @choose
-           : forall A : Type, ChoosableFromInterval A -> A * A -> G A  
+           : forall A : Type, ChoosableFromInterval A -> A * A -> G A
 *)
 
 (** The [ChoosableFromInterval] typeclass describes primitive types
@@ -94,9 +94,9 @@ Check @choose.
     sense to randomly generate elements from a given interval. *)
 
 Sample (choose (0,10)).
-(** 
-     ===> 
-       [ 1, 2, 1, 9, 8, 1, 3, 6, 2, 1, 8, 0, 1, 1, 3, 5, 4, 10, 4, 6 ] 
+(**
+     ===>
+       [ 1, 2, 1, 9, 8, 1, 3, 6, 2, 1, 8, 0, 1, 1, 3, 5, 4, 10, 4, 6 ]
 *)
 
 (** **** Exercise: 1 star, optional (cfi)  *)
@@ -113,33 +113,33 @@ Sample (choose (0,10)).
     type [A] and returns a generator for lists of [A]s. *)
 
 Check listOf.
-(** 
-     ===> 
-      listOf : G ?A -> G (list ?A) 
+(**
+     ===>
+      listOf : G ?A -> G (list ?A)
 *)
 
 Sample (listOf (choose (0,4))).
-(** 
-     ===> 
-      [ [ 0, 3, 2, 0 ], 
-        [ 1, 3, 4, 1, 0, 3, 0, 2, 2, 3, 2, 2, 2, 0, 4, 2, 3, 0, 1 ], 
-        [ 3, 4, 3, 1, 2, 4, 4, 1, 0, 3, 4, 3, 2, 2, 4, 4, 1 ], 
-        [ 0 ], 
-        [ 4, 2, 3 ], 
-        [ 3, 3, 4, 0, 1, 4, 3, 2, 4, 1 ], 
-        [ 0, 4 ], 
-        [  ], 
-        [ 1, 0, 1, 3, 1 ], 
-        [ 0, 0 ], 
-        [ 1, 4 ], 
-        [ 4, 3, 2, 0, 2, 2, 4, 0 ], 
-        [ 1, 1, 0, 0, 1, 4 ], 
-        [ 2, 0, 2, 1, 3, 3 ], 
-        [ 4, 3, 3, 0, 1 ], 
-        [ 3, 3, 3 ], 
-        [ 3, 2, 4 ], 
-        [ 1, 2 ], 
-        [  ], 
+(**
+     ===>
+      [ [ 0, 3, 2, 0 ],
+        [ 1, 3, 4, 1, 0, 3, 0, 2, 2, 3, 2, 2, 2, 0, 4, 2, 3, 0, 1 ],
+        [ 3, 4, 3, 1, 2, 4, 4, 1, 0, 3, 4, 3, 2, 2, 4, 4, 1 ],
+        [ 0 ],
+        [ 4, 2, 3 ],
+        [ 3, 3, 4, 0, 1, 4, 3, 2, 4, 1 ],
+        [ 0, 4 ],
+        [  ],
+        [ 1, 0, 1, 3, 1 ],
+        [ 0, 0 ],
+        [ 1, 4 ],
+        [ 4, 3, 2, 0, 2, 2, 4, 0 ],
+        [ 1, 1, 0, 0, 1, 4 ],
+        [ 2, 0, 2, 1, 3, 3 ],
+        [ 4, 3, 3, 0, 1 ],
+        [ 3, 3, 3 ],
+        [ 3, 2, 4 ],
+        [ 1, 2 ],
+        [  ],
         [  ] ]
 *)
 
@@ -147,31 +147,31 @@ Sample (listOf (choose (0,4))).
     argument [n], the length of the list to be generated. *)
 
 Check vectorOf.
-(** 
-     ===> 
-      vectorOf : nat -> G ?A -> G (list ?A) 
+(**
+     ===>
+      vectorOf : nat -> G ?A -> G (list ?A)
 *)
 
 Sample (vectorOf 3 (choose (0,4))).
-(** 
-     ===> 
-      [ [0, 1, 4], 
-        [1, 1, 0], 
-        [3, 3, 3], 
-        [0, 2, 1], 
-        [1, 3, 2], 
-        [3, 3, 0], 
-        [3, 0, 4], 
-        [2, 3, 3], 
-        [3, 2, 4], 
-        [1, 2, 3], 
+(**
+     ===>
+      [ [0, 1, 4],
+        [1, 1, 0],
+        [3, 3, 3],
+        [0, 2, 1],
+        [1, 3, 2],
+        [3, 3, 0],
+        [3, 0, 4],
+        [2, 3, 3],
+        [3, 2, 4],
+        [1, 2, 3],
         [2, 0, 4]  ]
 *)
 
 (** This raises a question.  It's clear how [vectorOf] decides how big
     to make its lists (we tell it!), but how does [listOf] do it?  The
     answer is hidden inside [G].
-  
+
     In addition to handling random-seed plumbing, the [G] monad also
     maintains a "current maximum size" (in the style of a "reader
     monad", if you like that terminology): a natural number [n] that
@@ -212,18 +212,18 @@ Instance show_color : Show color :=
     using [elements]. *)
 
 Check elements.
-(** 
-     ===> 
-      elements : ?A -> list ?A -> G ?A 
+(**
+     ===>
+      elements : ?A -> list ?A -> G ?A
 *)
 
 Definition genColor' : G color :=
   elements Red [ Red ; Green ; Blue ; Yellow ].
 
 Sample genColor'.
-(** 
-     ===> 
-     [Red, Green, Blue, Blue, Red, Yellow, Blue, Red, Blue, Blue, Red] 
+(**
+     ===>
+     [Red, Green, Blue, Blue, Red, Yellow, Blue, Red, Blue, Blue, Red]
 *)
 
 (** The first argument to [elements] serves as a default result.  If
@@ -234,7 +234,7 @@ Sample genColor'.
     typically its second argument will be a non-empty constant list.
     To make this common case smoother, QuickChick provides convenient
     notations that automatically extract the default. *)
-(** 
+(**
      " 'elems' [ x ] " := elements x (cons x nil)
      " 'elems' [ x ; y ] " := elements x (cons x (cons y nil))
      " 'elems' [ x ; y ; .. ; z ] " := elements x
@@ -248,9 +248,9 @@ Definition genColor : G color :=
   elems [ Red ; Green ; Blue ; Yellow ].
 
 Sample genColor.
-(** 
-      ===> 
-       [Red, Green, Blue, Blue, Red, Yellow, Blue, Red, Blue, Blue, Red] 
+(**
+      ===>
+       [Red, Green, Blue, Blue, Red, Yellow, Blue, Red, Blue, Blue, Red]
 *)
 
 (** For more complicated ADTs, QuickChick provides more combinators.
@@ -271,10 +271,10 @@ Arguments Node {A} _ _ _.
     declaration stems from the fact that Coq's typeclasses (unlike
     Haskell's) are not automatically recursive.  We could
     alternatively define [aux] with a separate top-level
-    [Fixpoint].) *) 
+    [Fixpoint].) *)
 
 Instance showTree {A} `{_ : Show A} : Show (Tree A) :=
-  {| show := 
+  {| show :=
        let fix aux t :=
          match t with
            | Leaf => "Leaf"
@@ -287,9 +287,9 @@ Instance showTree {A} `{_ : Show A} : Show (Tree A) :=
 (** Now we come to the first _generator combinator_, called [oneof]. *)
 
 Check oneof.
-(** 
-      ===> 
-       oneof : G ?A -> list (G ?A) -> G ?A 
+(**
+      ===>
+       oneof : G ?A -> list (G ?A) -> G ?A
 *)
 
 (** This combinator takes a default generator and a list of
@@ -340,8 +340,8 @@ Fixpoint genTreeSized {A} (sz : nat) (g : G A) : G (Tree A) :=
   end.
 
 Sample (genTreeSized 3 (choose(0,3))).
-(** 
-      ===> 
+(**
+      ===>
        [ Leaf,
          Leaf,
          Node (3) (Node (0) (Leaf) (Leaf))
@@ -375,9 +375,9 @@ Sample (genTreeSized 3 (choose(0,3))).
     default-lifting notation [freq]. *)
 
 Check frequency.
-(** 
-      ===> 
-       frequency : G ?A -> seq (nat * G ?A) -> G ?A 
+(**
+      ===>
+       frequency : G ?A -> seq (nat * G ?A) -> G ?A
 *)
 
 (** The more convenient form, [freq], takes a list of generators, each
@@ -388,7 +388,7 @@ Check frequency.
 
 Fixpoint genTreeSized' {A} (sz : nat) (g : G A) : G (Tree A) :=
   match sz with
-    | O => ret Leaf 
+    | O => ret Leaf
     | S sz' =>
         freq [ (1,  ret Leaf) ;
                (sz, liftM3 Node g (genTreeSized' sz' g)
@@ -397,9 +397,9 @@ Fixpoint genTreeSized' {A} (sz : nat) (g : G A) : G (Tree A) :=
   end.
 
 Sample (genTreeSized' 3 (choose(0,3))).
-(** 
-      ===> 
-         [ Node (3) (Node (1) (Node (3) (Leaf) (Leaf)) (Leaf)) 
+(**
+      ===>
+         [ Node (3) (Node (1) (Node (3) (Leaf) (Leaf)) (Leaf))
                     (Node (0) (Leaf) (Node (3) (Leaf) (Leaf))),
            Leaf,
            Node (2) (Node (1) (Leaf) (Leaf)) (Leaf),
@@ -410,23 +410,23 @@ Sample (genTreeSized' 3 (choose(0,3))).
                     (Node (2) (Leaf) (Leaf)),
            Node (1) (Node (3) (Node (2) (Leaf) (Leaf)) (Node (3) (Leaf) (Leaf)))
                     (Node (1) (Leaf) (Node (2) (Leaf) (Leaf))),
-           Node (0) (Node (0) (Node (0) (Leaf) (Leaf)) (Node (1) (Leaf) (Leaf))) 
+           Node (0) (Node (0) (Node (0) (Leaf) (Leaf)) (Node (1) (Leaf) (Leaf)))
                     (Node (2) (Node (3) (Leaf) (Leaf)) (Node (0) (Leaf) (Leaf))),
            Node (2) (Node (2) (Leaf) (Leaf)) (Node (1) (Node (2) (Leaf) (Leaf))
                                                        (Node (2) (Leaf) (Leaf))),
-           Node (2) (Node (3) (Node (2) (Leaf) (Leaf)) (Leaf)) 
+           Node (2) (Node (3) (Node (2) (Leaf) (Leaf)) (Leaf))
                     (Node (0) (Node (2) (Leaf) (Leaf)) (Leaf)),
            Leaf,
            Node (2) (Node (3) (Node (3) (Leaf) (Leaf)) (Leaf)) (Leaf),
            Leaf,
            Node (1) (Leaf) (Leaf),
            Leaf,
-           Node (1) (Node (2) (Leaf) (Node (3) (Leaf) (Leaf))) 
+           Node (1) (Node (2) (Leaf) (Node (3) (Leaf) (Leaf)))
                     (Node (0) (Leaf) (Node (1) (Leaf) (Leaf))),
            Leaf,
-           Node (3) (Node (0) (Node (0) (Leaf) (Leaf)) (Leaf)) 
+           Node (3) (Node (0) (Node (0) (Leaf) (Leaf)) (Leaf))
                     (Node (0) (Leaf) (Node (2) (Leaf) (Leaf))),
-           Node (2) (Node (2) (Node (0) (Leaf) (Leaf)) (Leaf)) 
+           Node (2) (Node (2) (Node (0) (Leaf) (Leaf)) (Leaf))
                     (Node (1) (Leaf) (Node (2) (Leaf) (Leaf))),
            Leaf ]
 *)
@@ -454,7 +454,7 @@ Sample (genTreeSized' 3 (choose(0,3))).
     finding counterexamples, suppose we define a function for
     "mirroring" a tree -- swapping its left and right subtrees
     recursively. *)
-   
+
 Fixpoint mirror {A : Type} (t : Tree A) : Tree A :=
   match t with
     | Leaf => Leaf
@@ -506,7 +506,7 @@ Definition Checker := G Result.
     function from trees to booleans.  But let's start simpler and see
     how to build a checker out of a [bool]. *)
 
-(**  Words needed 
+(**  Words needed
  *)
 Class Checkable A :=
   {
@@ -528,14 +528,14 @@ End CheckerPlayground1.
 Sample (CheckerPlayground1.checker true).
 (**
 
-      [Success, Success, Success, Success, Success, Success, Success, 
+      [Success, Success, Success, Success, Success, Success, Success,
        Success, Success, Success, Success]
 *)
 
 Sample (CheckerPlayground1.checker false).
 (**
 
-      [Failure, Failure, Failure, Failure, Failure, Failure, Failure, 
+      [Failure, Failure, Failure, Failure, Failure, Failure, Failure,
        Failure, Failure, Failure, Failure]
 *)
 
@@ -576,14 +576,14 @@ End CheckerPlayground2.
 Sample (CheckerPlayground1.checker CheckerPlayground2.c1).
 (**
 
-      [Failure, Failure, Failure, Failure, Failure, Failure, Failure, 
+      [Failure, Failure, Failure, Failure, Failure, Failure, Failure,
        Failure, Failure, Failure, Failure]
 *)
 
 Sample (CheckerPlayground1.checker CheckerPlayground2.c2).
 (**
 
-      [Success, Success, Success, Success, Success, Success, Success, 
+      [Success, Success, Success, Success, Success, Success, Success,
        Success, Success, Success, Success]
 *)
 
@@ -611,7 +611,7 @@ End CheckerPlayground3.
 Sample (CheckerPlayground3.forAll (genTreeSized' 3 (choose(0,3))) mirrorP).
 (**
 
-      [Success, Success, Success, Success, Success, Success, Success, 
+      [Success, Success, Success, Success, Success, Success, Success,
        Success, Success, Success, Success]
 *)
 
@@ -623,7 +623,7 @@ Definition faultyMirrorP (t : Tree nat) := eq_tree (mirror t) t.
 Sample (CheckerPlayground3.forAll (genTreeSized' 3 (choose(0,3))) faultyMirrorP).
 (**
 
-      [Failure, Success, Failure, Success, Success, Success, Failure, 
+      [Failure, Success, Failure, Success, Success, Success, Failure,
        Success, Failure, Failure, Success]
 *)
 
@@ -699,18 +699,18 @@ End CheckerPlayground4.
 Sample (CheckerPlayground4.forAll (genTreeSized' 3 (choose(0,3))) faultyMirrorP).
 (**
 
-      [Failure: (Node (2) (Node (3) (Node (2) (Leaf) (Leaf)) (Leaf)) 
-                          (Node (0) (Node (2) (Leaf) (Leaf)) (Leaf)), tt), 
-      Success, 
-      Failure: (Node (2) (Node (3) (Node (3) (Leaf) (Leaf)) (Leaf)) (Leaf), tt), 
-      Success, Success, Success, 
-      Failure: (Node (1) (Node (2) (Leaf) (Node (3) (Leaf) (Leaf))) 
-                         (Node (0) (Leaf) (Node (1) (Leaf) (Leaf))), tt), 
-      Success, 
-      Failure: (Node (3) (Node (0) (Node (0) (Leaf) (Leaf)) (Leaf)) 
-                         (Node (0) (Leaf) (Node (2) (Leaf) (Leaf))), tt), 
-      Failure: (Node (2) (Node (2) (Node (0) (Leaf) (Leaf)) (Leaf)) 
-                         (Node (1) (Leaf) (Node (2) (Leaf) (Leaf))), tt), 
+      [Failure: (Node (2) (Node (3) (Node (2) (Leaf) (Leaf)) (Leaf))
+                          (Node (0) (Node (2) (Leaf) (Leaf)) (Leaf)), tt),
+      Success,
+      Failure: (Node (2) (Node (3) (Node (3) (Leaf) (Leaf)) (Leaf)) (Leaf), tt),
+      Success, Success, Success,
+      Failure: (Node (1) (Node (2) (Leaf) (Node (3) (Leaf) (Leaf)))
+                         (Node (0) (Leaf) (Node (1) (Leaf) (Leaf))), tt),
+      Success,
+      Failure: (Node (3) (Node (0) (Node (0) (Leaf) (Leaf)) (Leaf))
+                         (Node (0) (Leaf) (Node (2) (Leaf) (Leaf))), tt),
+      Failure: (Node (2) (Node (2) (Node (0) (Leaf) (Leaf)) (Leaf))
+                         (Node (1) (Leaf) (Node (2) (Leaf) (Leaf))), tt),
       Success]
 *)
 
@@ -745,9 +745,9 @@ Sample (CheckerPlayground4.forAll (genTreeSized' 3 (choose(0,3))) faultyMirrorP)
     function for lists provided by QuickChick. *)
 
 Print shrinkList.
-(** 
-      ===> 
-       shrinkList = 
+(**
+      ===>
+       shrinkList =
          fix shrinkList (A : Type) (shr : A -> seq A) (l : seq A) {struct l} :
            seq (seq A) :=
            match l with
@@ -779,17 +779,17 @@ Fixpoint shrinkTree {A} (s : A -> list A) (t : Tree A) : list (Tree A) :=
                     map (fun r' => Node x l r') (shrinkTree s r)
   end.
 
-(**  Explain it 
+(**  Explain it
  *)
 (** Armed with [shrinkTree], we use the [forAllShrink] property
     combinator that takes an additional argument, a shrinker *)
 
 (* QuickChick (forAllShrink (genTreeSized' 5 (choose (0,5))) (shrinkTree shrink) faultyMirrorP). *)
-(** 
-      ===> 
+(**
+      ===>
        Node (0) (Leaf) (Node (0) (Leaf) (Leaf))
 
-       *** Failed! After 1 tests and 8 shrinks 
+       *** Failed! After 1 tests and 8 shrinks
 *)
 
 (** We now got a much simpler counterexample (in fact, this is one of
@@ -802,7 +802,7 @@ Fixpoint shrinkTree {A} (s : A -> list A) (t : Tree A) : list (Tree A) :=
 
 Inductive TernaryTree A :=
 | TLeaf : TernaryTree A
-| TNode : 
+| TNode :
     A -> TernaryTree A -> TernaryTree A -> TernaryTree A -> TernaryTree A.
 
 Arguments TLeaf {A}.
@@ -820,17 +820,17 @@ Fixpoint tern_mirror {A : Type} (t : TernaryTree A) : TernaryTree A :=
 (* In-order traversal of ternary tree *)
 Definition tern_to_list {A : Type} (t : TernaryTree A) : list A :=
   let fix aux t def :=
-      match t with 
+      match t with
       | TLeaf => def
-      | TNode x l m r => 
+      | TNode x l m r =>
         aux l [] ++ aux m [x] ++ aux r []
-      end in 
+      end in
   aux t [].
 
 (* Equality for ternary trees *)
-Instance eq_dec_ternary A (x y : TernaryTree A) 
+Instance eq_dec_ternary A (x y : TernaryTree A)
          `{D : forall x y : A, Dec (x = y)} : Dec (x = y).
-Proof. 
+Proof.
 constructor; unfold ssrbool.decidable.
 decide equality.
 destruct (D a a0); auto.
@@ -851,9 +851,9 @@ Import QcDoNotation.
 (* EX 3: Write a shrinker for ternary trees *)
 (* FILL IN HERE *)
 
-(* Converting a ternary tree to a list and reversing it should yield the same 
+(* Converting a ternary tree to a list and reversing it should yield the same
    list as mirroring the tree and then converting it *)
-Definition tern_mirror_reverse (t : TernaryTree nat) := 
+Definition tern_mirror_reverse (t : TernaryTree nat) :=
   tern_to_list (tern_mirror t) = List.rev (tern_to_list t) ?.
 
 (* EX 4 : Using genTernTreeSized and shrinkTernTree find any bugs in tern_mirror *)
@@ -865,7 +865,7 @@ Definition tern_mirror_reverse (t : TernaryTree nat) :=
 (* ################################################################# *)
 (** * Putting it all Together *)
 
-(**  typeclass magic to hide forAll (requires introducing Gen and GenSized) 
+(**  typeclass magic to hide forAll (requires introducing Gen and GenSized)
  *)
 (** QuickChick, just like QuickCheck, provides an [Arbitrary]
     typeclass parameterized over some type [A] with two objects:
@@ -876,11 +876,11 @@ Definition tern_mirror_reverse (t : TernaryTree nat) :=
     to use [genTreeSized']; however that generator takes an additional
     size argument.  The [G] monad will provide that argument through
     the combinator [sized].*)
-    
+
 Check sized.
-(** 
-      ===> 
-        sized : (nat -> G ?A) -> G ?A 
+(**
+      ===>
+        sized : (nat -> G ?A) -> G ?A
 *)
 
 (** [sized] receives a function that given a number produces a
@@ -889,10 +889,10 @@ Check sized.
 
     The [shrink] function is simply a shrinker like [shrinkTree]. *)
 
-Instance genTree {A} `{Gen A} : GenSized (Tree A) := 
+Instance genTree {A} `{Gen A} : GenSized (Tree A) :=
   {| arbitrarySized n := genTreeSized n arbitrary |}.
 
-Instance shrTree {A} `{Shrink A} : Shrink (Tree A) := 
+Instance shrTree {A} `{Shrink A} : Shrink (Tree A) :=
   {| shrink x := shrinkTree shrink x |}.
 
 (** With this [Arbitrary] instance we can once again use the toplevel
@@ -905,7 +905,7 @@ Instance shrTree {A} `{Shrink A} : Shrink (Tree A) :=
     [Checkable]? It is easy to see how a boolean is [Checkable]; we
     can always tell if it is true or not and then return a [Result],
     [Success]/[Failure] as appropriate.
-    
+
     To see how executable properties are [Checkable], consider a
     single argument function [p : A -> Bool] that returns a
     boolean. If we know that [A] has [Show] and [Arbitrary] instances,
@@ -973,12 +973,12 @@ Fixpoint size {A} (t : Tree A) : nat :=
     below. *)
 
 Definition treeProp (g : nat -> G nat -> G (Tree nat)) n :=
-  forAll (g n (choose (0,n))) (fun t => 
+  forAll (g n (choose (0,n))) (fun t =>
   collect (size t) true).
 
 (* QuickChick (treeProp genTreeSized  5). *)
-(** 
-      ===> 
+(**
+      ===>
        4947 : 0
        1258 : 1
        673 : 2
@@ -1009,8 +1009,8 @@ Definition treeProp (g : nat -> G nat -> G (Tree nat)) n :=
     [Nodes], while too few tests have larger sizes. Compare that with
     [genTreeSized'] below.  *)
 
-(* QuickChick (treeProp genTreeSized' 5). *)(** 
-      ===> 
+(* QuickChick (treeProp genTreeSized' 5). *)(**
+      ===>
        1624 : 0
        571 : 10
        564 : 12
@@ -1051,19 +1051,19 @@ Definition treeProp (g : nat -> G nat -> G (Tree nat)) n :=
 
 (* Dealing with preconditions *)
 (* Consider inserting in a sorted list *)
-Fixpoint insert (x : nat) (l : list nat) := 
-  match l with 
-  | [] => [x] 
+Fixpoint insert (x : nat) (l : list nat) :=
+  match l with
+  | [] => [x]
   | y::ys => if x <=? y then x :: l else y :: insert x ys
   end.
 
 (* Leo: Scoping/associativity between <? / &&. Maybe just andb? *)
 Open Scope bool.
-Fixpoint sorted (l : list nat) := 
-  match l with 
+Fixpoint sorted (l : list nat) :=
+  match l with
   | [] => true
-  | x::xs => 
-    match xs with 
+  | x::xs =>
+    match xs with
     | [] => true
     | y :: ys => (x <=? y) && (sorted xs)
     end
@@ -1089,11 +1089,11 @@ Definition insert_spec' (x : nat) (l : list nat) :=
 (* For properties with preconditions, we write custom generators that satisfy the property directly! *)
 (* Let's generate sorted lists with elements between low and high *)
 Fixpoint genSortedList (low high : nat) (size : nat) : G (list nat) :=
-  match size with 
+  match size with
   | O => returnGen []
   | S size' =>
     if high <? low then returnGen []
-    else freq [ (1, returnGen []) 
+    else freq [ (1, returnGen [])
               ; (size, do! x  <- choose (low, high);
                        do! xs <- genSortedList x high size';
                        returnGen (x :: xs)) ]
@@ -1102,7 +1102,7 @@ Fixpoint genSortedList (low high : nat) (size : nat) : G (list nat) :=
 Sample (genSortedList 0 10 10).
 
 Definition insert_spec_sorted (x : nat) :=
-  forAllShrink (genSortedList 0 10 10) shrink 
+  forAllShrink (genSortedList 0 10 10) shrink
                (fun l => insert_spec' x l).
 
 (* QuickChick insert_spec_sorted. *)
@@ -1111,7 +1111,7 @@ Definition insert_spec_sorted (x : nat) :=
 (** But are we done yet? *)
 
 (* EX (hard)
-   
+
    Using "collect", figure out whether generating a sorted list of numbers
    between 0 and 5 is uniform in the frequencies of the numbers generated.
 
@@ -1124,8 +1124,8 @@ Definition insert_spec_sorted (x : nat) :=
 
 
 (* EX : Binary Search Trees *)
-Fixpoint isBST (low high: nat) (t : Tree nat) := 
-  match t with 
+Fixpoint isBST (low high: nat) (t : Tree nat) :=
+  match t with
   | Leaf => true
   | Node x l r => (low <? x) && (x <? high)
                   && (isBST low x l) && (isBST x high r)
@@ -1133,21 +1133,21 @@ Fixpoint isBST (low high: nat) (t : Tree nat) :=
 
 (* Give them insert or have them write it? *)
 Fixpoint insertBST (x : nat) (t : Tree nat) :=
-  match t with 
+  match t with
   | Leaf => Node x Leaf Leaf
   | Node x' l r => if x <? x' then Node x' (insertBST x l) r
                    else Node x' l (insertBST x r)
   end.
 
 Definition insertBST_spec (low high : nat) (x : nat) (t : Tree nat) :=
-  (low <? x) ==> (x <? high) ==> (isBST low high t) ==> 
-  isBST low high (insertBST x t).                         
+  (low <? x) ==> (x <? high) ==> (isBST low high t) ==>
+  isBST low high (insertBST x t).
 
 (* QuickChick insertBST_spec. *)
 (* Too much wasted effort: 16 tests - 270 discards! *)
 
 Fixpoint insertBST' (x : nat) (t : Tree nat) :=
-  match t with 
+  match t with
   | Leaf => Node x Leaf Leaf
   | Node x' l r => if x <? x' then Node x' (insertBST' x l) r
                    else if x' <? x then Node x' l (insertBST' x r)
@@ -1155,12 +1155,12 @@ Fixpoint insertBST' (x : nat) (t : Tree nat) :=
   end.
 
 Definition insertBST_spec' (low high : nat) (x : nat) (t : Tree nat) :=
-  (low <? x) ==> (x <? high) ==> (isBST low high t) ==> 
-  isBST low high (insertBST' x t).                         
+  (low <? x) ==> (x <? high) ==> (isBST low high t) ==>
+  isBST low high (insertBST' x t).
 
 (* QuickChick insertBST_spec'. *)
 (* Fixing the bug ==> Gave up! *)
 
-(* EX : Binary search tree generator 
-Write a generator that produces binary search trees directly, so that 
+(* EX : Binary search tree generator
+Write a generator that produces binary search trees directly, so that
 you run 10000 tests with 0 discards *)

--- a/qc/TImp.v
+++ b/qc/TImp.v
@@ -34,7 +34,7 @@ Require Import QC.
     expressions, while [aexp] ranges over arithmetic ones.  Moreover,
     variables are only allowed in [aexp] and only take arithmetic
     values.
-    
+
     In typed Imp (TImp) we collapse the expression syntax and allow
     variables to range over both numbers and booleans. With the
     unified syntax, we introduce the notion of well-typed Imp
@@ -97,7 +97,7 @@ Module Atom : ATOM.
 (** ...which means decidable equality comes for free from the standard library: *)
 
   Definition eq_dec := eq_nat_dec.
-  
+
 (** To compute a fresh natural number given a list of natural numbers,
     we can just produce the number that is 1 larger than the maximum
     element: *)
@@ -113,11 +113,11 @@ Module Atom : ATOM.
 
   Include HasUsualEq <+ UsualIsEq.
 
-(** We also need a way of printing atoms. To support that, we include a 
+(** We also need a way of printing atoms. To support that, we include a
     [nat_of] function that exposes the internal natural number. *)
-  
+
   Definition nat_of (a : nat) := a.
-  
+
 End Atom.
 
 (** We can take advantage of the [nat_of] function of [Atom]s, as well
@@ -126,7 +126,7 @@ End Atom.
 Instance show_atom : Show Atom.t :=
   {| show x := show (Atom.nat_of x) |}.
 
-(** To generate identifiers for TImp, we will use a recursive functions 
+(** To generate identifiers for TImp, we will use a recursive functions
     that generates [n] fresh [Atom]s starting from the empty list. *)
 
 Fixpoint get_fresh_atoms n l :=
@@ -140,7 +140,7 @@ Fixpoint get_fresh_atoms n l :=
 
 (** To continue, here is the type of types in TImp, [ty]: *)
 
-Inductive ty := TBool | TNat. 
+Inductive ty := TBool | TNat.
 
 (** TImp has two types of expressions: booleans and natural numbers. *)
 
@@ -148,10 +148,10 @@ Inductive ty := TBool | TNat.
     we will need [Arbitrary], [Show] and an equality [Dec] instance.
 
     In QC.v, we saw how one can go about writing such generators by hand.
-    However, that process can largely be automated, especially for 
-    simple inductive types (like [ty], [nat], [list], [tree], etc.). 
-    QuickChick provides a top-level vernacular command to derive 
-    such instances. 
+    However, that process can largely be automated, especially for
+    simple inductive types (like [ty], [nat], [list], [tree], etc.).
+    QuickChick provides a top-level vernacular command to derive
+    such instances.
  *)
 
 Derive (Arbitrary, Show) for ty.
@@ -172,26 +172,26 @@ Proof. constructor; unfold ssrbool.decidable; decide equality. Defined.
 (* ================================================================= *)
 (** ** List Map with Decidable Equality *)
 
-(** To encode typing environments and, later on, states, we will need 
-    maps from atoms to values. The function-based representation in base 
-    Imp is not suited for testing: we will need to be able to access the 
+(** To encode typing environments and, later on, states, we will need
+    maps from atoms to values. The function-based representation in base
+    Imp is not suited for testing: we will need to be able to access the
     domain of the map, fold over it and test for equality; all operations
-    not supported by (Coq) functions. Therefore, we introduce a small 
+    not supported by (Coq) functions. Therefore, we introduce a small
     list-based map that takes usual decidable types (like [Atom]) as input.
 
     The operations we need are:
-    
+
        - [empty] : To create the empty map.
        - [get]   : To look up the binding of an element, if any.
        - [set]   : To update the binding of an element.
        - [dom]   : To get the list of keys in the map.
   *)
-    
+
 Module Type Map (K:UsualDecidableType).
 
  Section withv.
    Variable V : Type.
-    
+
    Parameter t : Type -> Type.
    Parameter empty : t V.
    Parameter get : t V -> K.t -> option V.
@@ -201,9 +201,9 @@ Module Type Map (K:UsualDecidableType).
 
 End Map.
 
-(** The implementation of the map is a simple association list. 
-    If a list contains multiple tuples with the same key, then 
-    the binding of the key in the map is the one that appears firt 
+(** The implementation of the map is a simple association list.
+    If a list contains multiple tuples with the same key, then
+    the binding of the key in the map is the one that appears firt
     in the list; that is, bindings can be shadowed.
   *)
 
@@ -211,22 +211,22 @@ Module ListMap (K:UsualDecidableType) <: Map K.
 
  Section withv.
    Context {V : Type}.
-    
+
    Definition t := list (K.t * V).
-    
+
    Definition empty : t := [].
-    
-   Fixpoint get m k : option V := 
+
+   Fixpoint get m k : option V :=
      match m with
        | [] => None
        | (k', v) :: m' => if K.eq_dec k k'
                           then Some v
                           else get m' k
      end.
-    
+
    Definition set (m:t) (k:K.t) (v:V) : t :=
      (k, v) :: m.
-    
+
    Fixpoint dom (m:t) : list K.t :=
      match m with
        | [] => []
@@ -237,14 +237,14 @@ Module ListMap (K:UsualDecidableType) <: Map K.
 
 End ListMap.
 
-(** We instantiate this functor with [Atom], yielding [AtomMap] our 
+(** We instantiate this functor with [Atom], yielding [AtomMap] our
     map with [Atom] as the key type. *)
 
 Module AtomMap := ListMap (Atom).
 
-(** We introduce a simple inductive proposition, [bind_in m x a], that 
-    holds precisely when the binding of some [Atom] [x] is equal to [a] in 
-    [m] 
+(** We introduce a simple inductive proposition, [bind_in m x a], that
+    holds precisely when the binding of some [Atom] [x] is equal to [a] in
+    [m]
   *)
 (* BCP: My usual convention is to put ending comment brackets on the
    same line as the end of the comment... *)
@@ -254,34 +254,34 @@ Module AtomMap := ListMap (Atom).
 Inductive bind_in {A} : @AtomMap.t A -> Atom.t -> A -> Prop :=
   | Bind : forall x m a, AtomMap.get m x = Some a -> bind_in m x a.
 
-(** We can now decide whether [bind_in m x a] holds for a given 
+(** We can now decide whether [bind_in m x a] holds for a given
     arrangement of [m], [x] and [a]. In a first reading, you can
-    skip the next few paragraphs that deal with partially automating 
-    the proofs for such instances. 
+    skip the next few paragraphs that deal with partially automating
+    the proofs for such instances.
   *)
 (* BCP: Be explicit about where to skip to.  (Or perhaps break it up
    into subsections so that people can just skip the whole
    subsection?)  [Ah, I see that it's already done this way,
    basically.] *)
 
-Instance dec_bind_in {A : Type} Gamma x (T : A) 
+Instance dec_bind_in {A : Type} Gamma x (T : A)
          `{D : forall (x y : A), Dec (x = y)}
   : Dec (bind_in Gamma x T) := {}.
-Proof. 
-  unfold ssrbool.decidable. 
+Proof.
+  unfold ssrbool.decidable.
   destruct (AtomMap.get Gamma x) eqn:Get.
-      
+
 (** After unfolding [decidable] and destructing [AtomMap.get Gamma x], we are
     left with two subgoals. In the first, we know that [AtomMap.get Gamma x =
     Some a] and effectively want to decide whether [AtomMap.get Gamma x = Some
     T] or not. Which means we need to decide whether [a = T]. Thankfully,
-    we can decide that using our hypothesis [D]. 
+    we can decide that using our hypothesis [D].
   *)
-  
+
   - destruct (D a T) as [[Eq | NEq]]; subst.
 
 (** At this point, the first goal can be immediately decided positevely
-    using constructor. 
+    using constructor.
   *)
 
     + left. constructor. auto.
@@ -291,38 +291,38 @@ Proof.
     + right; intro Contra; inversion Contra; subst; clear Contra.
       congruence.
 
-(** Both of these tactic patterns are very common in non-trival [Dec] 
+(** Both of these tactic patterns are very common in non-trival [Dec]
     instances. For that reason, we automate them a bit using LTac.
   *)
 
 Abort.
 
-(** A lot of the time, we can immediately decide a property positevly 
+(** A lot of the time, we can immediately decide a property positevly
     using constructor applications. That is captured in [solve_left]. *)
 
 Ltac solve_left  := try solve [left; econstructor; eauto].
 
-(** Much of the time, we can also immediately decide that a property 
+(** Much of the time, we can also immediately decide that a property
     doesn't hold by assuming it, doing inversion and using [congruence].
   *)
 
-Ltac solve_right := 
+Ltac solve_right :=
   let Contra := fresh "Contra" in
-  try solve [right; intro Contra; inversion Contra; subst; clear Contra; 
+  try solve [right; intro Contra; inversion Contra; subst; clear Contra;
              eauto; congruence].
 
-(** We group both in a single tactic, which does nothing at all if 
+(** We group both in a single tactic, which does nothing at all if
     it fails to solve a goal, thanks to [try solve]. *)
 
 Ltac solve_sum := solve_left; solve_right.
 
 (** We can now prove the [Dec] instance more concisely. *)
 
-Instance dec_bind_in {A : Type} Gamma x (T : A) 
+Instance dec_bind_in {A : Type} Gamma x (T : A)
          `{D : forall (x y : A), Dec (x = y)}
   : Dec (bind_in Gamma x T) := {}.
-Proof. 
-  unfold ssrbool.decidable. 
+Proof.
+  unfold ssrbool.decidable.
   destruct (AtomMap.get Gamma x) eqn:Get; solve_sum.
   destruct (D a T) as [[Eq | NEq]]; subst; solve_sum.
 Defined.
@@ -334,50 +334,50 @@ Defined.
 
 Definition context := @AtomMap.t ty.
 
-(** Given a context [Gamma] and a type [T], we can try to generate 
-    a random [Atom] whose binding in [Gamma] is [T]. 
+(** Given a context [Gamma] and a type [T], we can try to generate
+    a random [Atom] whose binding in [Gamma] is [T].
 
     We filter out all of the elements in [Gamma] whose type is
-    equal to [T] and then, for each [(a,T')] that remains we 
-    return the binding [a]. We use the [oneof] combinator to 
-    pick an generator from that list at random. 
-    
+    equal to [T] and then, for each [(a,T')] that remains we
+    return the binding [a]. We use the [oneof] combinator to
+    pick an generator from that list at random.
+
     However, the filtered list might be empty; to facilitate
     that case, [oneof] also takes a default generator, here [ret None].
   *)
-    
+
 Definition gen_typed_atom_from_context (Gamma : context) (T : ty)
                                      : G (option Atom.t) :=
-  oneof (ret None) 
+  oneof (ret None)
         (List.map (fun '(a,T') => ret (Some a))
                   (List.filter (fun '(a,T') => T = T'?) Gamma)).
 
-(** We also need to generate a typing context to begin with. Given 
-    some natural number [n] to serve as the size of the context, 
-    we first create its domain, [n] fresh atoms. 
-    
-    We then create [n] arbitrary types with [vectorOf], using the 
+(** We also need to generate a typing context to begin with. Given
+    some natural number [n] to serve as the size of the context,
+    we first create its domain, [n] fresh atoms.
+
+    We then create [n] arbitrary types with [vectorOf], using the
     [Gen] instance for [ty] we derived earlier.
-  
-    Finally, we zip ([List.combine]) the domain with the ranges and 
+
+    Finally, we zip ([List.combine]) the domain with the ranges and
     fold over the resulting, inserting each binding into a map.
   *)
 
-Definition gen_context (n : nat) : G context := 
+Definition gen_context (n : nat) : G context :=
   let domain := get_fresh_atoms n [] in
   range <- vectorOf n arbitrary ;;
-  ret (List.fold_left (fun m '(k, v) => AtomMap.set m k v) 
+  ret (List.fold_left (fun m '(k, v) => AtomMap.set m k v)
                       (List.combine domain range) AtomMap.empty).
 
 (* ################################################################# *)
 (** * Expressions *)
 
-(** We are now ready to introduce the syntax of expressions in TImp. 
+(** We are now ready to introduce the syntax of expressions in TImp.
     The original Imp had two distinct types of expressions: arithmetic
-    and boolean expressions, while variables were only allowed to 
-    range over natural numbers. In TImp, we extend variables to range 
-    over boolean values as well, collapsing the expressions into a single 
-    type [exp]. 
+    and boolean expressions, while variables were only allowed to
+    range over natural numbers. In TImp, we extend variables to range
+    over boolean values as well, collapsing the expressions into a single
+    type [exp].
 
  *)
 
@@ -399,60 +399,60 @@ Inductive exp : Type :=
 
 Derive Show for exp.
 
-(** If we tried to derive [Arbitrary] for expressions we would 
-    encounter an error message: 
-    
-    ==> Unable to satisfy the following constraints: 
+(** If we tried to derive [Arbitrary] for expressions we would
+    encounter an error message:
+
+    ==> Unable to satisfy the following constraints:
         [Gen Atom.t]
 
     Indeed, we don't have an arbitrary instance for [Atom.t].
 
   *)
 
-(* EX 3 : Write an instance for [Gen] for [Atom.t], using 
-   [elements] and [get_fresh_atoms]. 
+(* EX 3 : Write an instance for [Gen] for [Atom.t], using
+   [elements] and [get_fresh_atoms].
  *)
 
-(* FILL IN HERE *)   
+(* FILL IN HERE *)
 
 (* ================================================================= *)
 (** ** Typed Expressions *)
 
 (** The following inductive relation characterizes well-typed expressions
-    of a particular type. It is rather unsurprising, using [bind_in] to 
+    of a particular type. It is rather unsurprising, using [bind_in] to
     access the typing context in the variable case *)
 
 (* BCP: Maybe define a Notation for this to lighten the presentation? *)
 
-Inductive has_type : context -> exp -> ty -> Prop := 
-| Ty_Var : forall x T Gamma, 
-    bind_in Gamma x T -> 
+Inductive has_type : context -> exp -> ty -> Prop :=
+| Ty_Var : forall x T Gamma,
+    bind_in Gamma x T ->
     has_type Gamma (EVar x) T
-| Ty_Num : forall Gamma n, 
+| Ty_Num : forall Gamma n,
     has_type Gamma (ENum n) TNat
-| Ty_Plus : forall Gamma e1 e2, 
+| Ty_Plus : forall Gamma e1 e2,
     has_type Gamma e1 TNat -> has_type Gamma e2 TNat ->
     has_type Gamma (EPlus e1 e2) TNat
-| Ty_Minus : forall Gamma e1 e2, 
+| Ty_Minus : forall Gamma e1 e2,
     has_type Gamma e1 TNat -> has_type Gamma e2 TNat ->
     has_type Gamma (EMinus e1 e2) TNat
-| Ty_Mult : forall Gamma e1 e2, 
+| Ty_Mult : forall Gamma e1 e2,
     has_type Gamma e1 TNat -> has_type Gamma e2 TNat ->
     has_type Gamma (EMult e1 e2) TNat
-| Ty_True : forall Gamma, 
+| Ty_True : forall Gamma,
     has_type Gamma ETrue TBool
-| Ty_False : forall Gamma, 
+| Ty_False : forall Gamma,
     has_type Gamma EFalse TBool
-| Ty_Eq : forall Gamma e1 e2, 
+| Ty_Eq : forall Gamma e1 e2,
     has_type Gamma e1 TNat -> has_type Gamma e2 TNat ->
     has_type Gamma (EEq e1 e2) TBool
-| Ty_Le : forall Gamma e1 e2, 
+| Ty_Le : forall Gamma e1 e2,
     has_type Gamma e1 TNat -> has_type Gamma e2 TNat ->
     has_type Gamma (ELe e1 e2) TBool
-| Ty_Not : forall Gamma e, 
+| Ty_Not : forall Gamma e,
     has_type Gamma e TBool ->
     has_type Gamma (ENot e) TBool
-| Ty_And : forall Gamma e1 e2, 
+| Ty_And : forall Gamma e1 e2,
     has_type Gamma e1 TBool -> has_type Gamma e2 TBool ->
     has_type Gamma (EAnd e1 e2) TBool.
 
@@ -460,21 +460,21 @@ Inductive has_type : context -> exp -> ty -> Prop :=
 (* BCP: And we may need to hack sf/Common.Makefile a bit so that we
    can leave this file out of the TOC. *)
 Ltac solve_inductives Gamma :=
-  repeat (match goal with 
+  repeat (match goal with
       [ IH : forall _ _, _ |- _ ] =>
-      let H1 := fresh "H1" in 
+      let H1 := fresh "H1" in
       pose proof (IH TNat Gamma) as H1;
-      let H2 := fresh "H2" in 
+      let H2 := fresh "H2" in
       pose proof (IH TBool Gamma) as H2;
       clear IH;
       destruct H1; destruct H2; solve_sum
     end).
 
-(** Typing in TImp is decidable: given an expression [e], a context [Gamma] 
-    and a type [T], we can decide whether [has_type Gamma e T] holds. 
+(** Typing in TImp is decidable: given an expression [e], a context [Gamma]
+    and a type [T], we can decide whether [has_type Gamma e T] holds.
     We implement that in a [Dec] instance. *)
 
-Instance dec_has_type (e : exp) (Gamma : context) (T : ty) 
+Instance dec_has_type (e : exp) (Gamma : context) (T : ty)
   : Dec (has_type Gamma e T) :=
   { dec := _ }.
 Proof with solve_sum.
@@ -488,9 +488,9 @@ Proof with solve_sum.
   destruct (dec_bind_in Gamma t T); destruct dec; solve_sum.
 Defined.
 
-(* EX 4 : Derive [Arbitrary] for expressions and write a conditional 
-    property that is always true if an expression is well-typed. Try to 
-    check that property. What happens?  
+(* EX 4 : Derive [Arbitrary] for expressions and write a conditional
+    property that is always true if an expression is well-typed. Try to
+    check that property. What happens?
 
     (You will need to provide a [Shrink] instance for [Atom]. The
     result of shrinking an atom can be empty for now)
@@ -509,23 +509,23 @@ Defined.
     if we wanted to generate an expression of type [TNat] and chose to
     do that by generating a variable, then we might not be able to
     actually do that (e.g. if the context is empty).
-   
+
 *)
 
-(** To chain two different generetors with type [G (option A)], we need to 
-    execute the first generator, match on its result, and, when it is a [Some], 
+(** To chain two different generetors with type [G (option A)], we need to
+    execute the first generator, match on its result, and, when it is a [Some],
     apply the second generator.
   *)
 
-Definition bindGenOpt {A B : Type} (gma : G (option A)) (k : A -> G (option B)) 
+Definition bindGenOpt {A B : Type} (gma : G (option A)) (k : A -> G (option B))
   : G (option B) :=
   ma <- gma ;;
-  match ma with 
-  | Some a => k a 
+  match ma with
+  | Some a => k a
   | None => ret None
   end.
 
-(** This pattern is common enough that QuickChick provides explicit monadic 
+(** This pattern is common enough that QuickChick provides explicit monadic
     notation support *)
 
 Definition GOpt A := G (option A).
@@ -551,15 +551,15 @@ Instance gOptMonad : `{Monad GOpt} :=
 
       [ backtrack : list (nat * G (option ?A)) -> G (option ?A) ]
 
-    which operates similarly to frequency for optional generators. 
-    However, unlike frequency, if the generator that was selected 
+    which operates similarly to frequency for optional generators.
+    However, unlike frequency, if the generator that was selected
     first fails (returns [None]), then [backtrack] proceeds to pick
-    one of the remaining ones until it runs out or one succeeds. 
+    one of the remaining ones until it runs out or one succeeds.
 
   *)
 
 (** We will break the generator into smaller bits.
-    
+
     Let's start with the first derivation of [has_type], [Ty_Var].
 
     [Ty_Var : forall (x : Atom.t) (T : ty) (Gamma : AtomMap.t),
@@ -578,83 +578,83 @@ Definition gen_typed_evar (Gamma : context) (T : ty) : G (option exp) :=
   x <- gen_typed_atom_from_context Gamma T;;
   ret (EVar x).
 
-(** For the rest of the base cases, we need to pattern match on the 
-    input type [T]: if it is [TNat], then we need to generate an arbitrary 
-    integer [n] and wrap it in an [ENum]; if it is [TBool], we need to pick 
-    between [ETrue] and [EFalse]. 
-   
-    Since [base] will be the input to [backtrack], we need to add natural numbers 
-    as weights. Since this example is simple enough, we selected [1] for 
-    all weights. In larger applications, we would need to fine tune these 
-    weights to obtain a desired distribution. 
+(** For the rest of the base cases, we need to pattern match on the
+    input type [T]: if it is [TNat], then we need to generate an arbitrary
+    integer [n] and wrap it in an [ENum]; if it is [TBool], we need to pick
+    between [ETrue] and [EFalse].
+
+    Since [base] will be the input to [backtrack], we need to add natural numbers
+    as weights. Since this example is simple enough, we selected [1] for
+    all weights. In larger applications, we would need to fine tune these
+    weights to obtain a desired distribution.
   *)
 
-Definition base Gamma T := 
+Definition base Gamma T :=
       (2, gen_typed_evar Gamma T) ::
-      match T with 
+      match T with
       | TNat  => [ (2, n <- arbitrary;; ret (Some (ENum n)))]
       | TBool => [ (1, ret ETrue)
                  ; (1, ret EFalse) ]
       end.
 
-(** In the recursive branches, we also need to pattern match on [T]. 
-    If, for example, [T = TNat], then we can only satisfy typing 
-    derivations whose conclusion is of the form [has_type Gamma _ TNat], 
-    i.e. [Ty_Plus], [Ty_Minus] and [Ty_Mult]. 
+(** In the recursive branches, we also need to pattern match on [T].
+    If, for example, [T = TNat], then we can only satisfy typing
+    derivations whose conclusion is of the form [has_type Gamma _ TNat],
+    i.e. [Ty_Plus], [Ty_Minus] and [Ty_Mult].
 
-    Consider [Ty_Plus]: we will need to recursively generate 
-    expressions [e1] and [e2] that have type [TNat], with potentially smaller 
-    sizes to ensure termination. 
+    Consider [Ty_Plus]: we will need to recursively generate
+    expressions [e1] and [e2] that have type [TNat], with potentially smaller
+    sizes to ensure termination.
 
     We put everything together in the following generator *)
 
 Fixpoint gen_exp_typed_sized (size : nat) (Gamma : context) (T : ty) : G (option exp) :=
   let base := base Gamma T in
-  let recs size' := 
-      match T with 
-      | TNat => [ (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                      e2 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                      ret (EPlus e1 e2)) 
-                ; (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                      e2 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                      ret (EMinus e1 e2)) 
-                ; (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                      e2 <- gen_exp_typed_sized size' Gamma TNat ;; 
+  let recs size' :=
+      match T with
+      | TNat => [ (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;;
+                      e2 <- gen_exp_typed_sized size' Gamma TNat ;;
+                      ret (EPlus e1 e2))
+                ; (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;;
+                      e2 <- gen_exp_typed_sized size' Gamma TNat ;;
+                      ret (EMinus e1 e2))
+                ; (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;;
+                      e2 <- gen_exp_typed_sized size' Gamma TNat ;;
                       ret (EMult e1 e2)) ]
-      | TBool => [ (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                       e2 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                       ret (EEq e1 e2)) 
-                 ; (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                       e2 <- gen_exp_typed_sized size' Gamma TNat ;; 
-                       ret (ELe e1 e2)) 
-                 ; (size, e1 <- gen_exp_typed_sized size' Gamma TBool ;; 
+      | TBool => [ (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;;
+                       e2 <- gen_exp_typed_sized size' Gamma TNat ;;
+                       ret (EEq e1 e2))
+                 ; (size, e1 <- gen_exp_typed_sized size' Gamma TNat ;;
+                       e2 <- gen_exp_typed_sized size' Gamma TNat ;;
+                       ret (ELe e1 e2))
+                 ; (size, e1 <- gen_exp_typed_sized size' Gamma TBool ;;
                        ret (ENot e1))
-                 ; (size, e1 <- gen_exp_typed_sized size' Gamma TBool ;; 
-                       e2 <- gen_exp_typed_sized size' Gamma TBool ;; 
+                 ; (size, e1 <- gen_exp_typed_sized size' Gamma TBool ;;
+                       e2 <- gen_exp_typed_sized size' Gamma TBool ;;
                        ret (EAnd e1 e2)) ]
       end in
-  match size with 
-  | O => 
-    backtrack base 
-  | S size' => 
+  match size with
+  | O =>
+    backtrack base
+  | S size' =>
     backtrack (base ++ recs size')
   end.
 
-(** When writing such complex generators, it's good to have small tests 
-    that ensure that you are generating what you expect. For example, we 
-    would expect [gen_exp_typed_sized] to always return expressions that are 
-    well typed. 
-    
-    We can use [forAll] to encode such a property. 
+(** When writing such complex generators, it's good to have small tests
+    that ensure that you are generating what you expect. For example, we
+    would expect [gen_exp_typed_sized] to always return expressions that are
+    well typed.
+
+    We can use [forAll] to encode such a property.
   *)
 
 Definition gen_typed_has_type :=
   let num_vars := 4 in
-  let top_level_size := 3 in 
+  let top_level_size := 3 in
   forAll (gen_context num_vars) (fun Gamma =>
-  forAll arbitrary (fun T =>                                   
+  forAll arbitrary (fun T =>
   forAll (gen_exp_typed_sized top_level_size Gamma T) (fun me =>
-  match me with 
+  match me with
   | Some e => (has_type Gamma e T)?
   | _ => false (* this should NEVER fail *)
   end))).
@@ -668,8 +668,8 @@ Definition gen_typed_has_type :=
 (** ** Values *)
 
 (** In original Imp, variables range over natural numbers, so states were just
-    maps from identifiers to [nat]. Since we wanted to extend this to also 
-    include booleans, we introduce the type of [value]s which includes both. 
+    maps from identifiers to [nat]. Since we wanted to extend this to also
+    include booleans, we introduce the type of [value]s which includes both.
   *)
 
 
@@ -679,7 +679,7 @@ Derive Show for value.
 
 (** We can also quickly define a typing relation for values, a Dec instance
     for it and a generator for values of a given type. *)
-  
+
 Inductive has_type_value : value -> ty -> Prop :=
   | TyVNat  : forall n, has_type_value (VNat  n) TNat
   | TyVBool : forall b, has_type_value (VBool b) TBool.
@@ -690,7 +690,7 @@ destruct v; destruct T; solve_sum.
 Defined.
 
 Definition gen_typed_value (T : ty) : G value :=
-  match T with 
+  match T with
   | TNat  => n <- arbitrary;; ret (VNat n)
   | TBool => b <- arbitrary;; ret (VBool b)
   end.
@@ -703,23 +703,23 @@ Definition gen_typed_value (T : ty) : G value :=
 Definition state := @AtomMap.t value.
 
 (** We introduce an inductive relation that specifies when a state
-    is well-typed according to a context: that is, when all of 
-    its variables are mapped to values of appropriate types. 
-  
-    We encode this in an element-by-element style inductive relation: 
-    empty states are only well-typed with respect to an empty context, 
-    while non-empty states need to map their head atom to a value of the 
+    is well-typed according to a context: that is, when all of
+    its variables are mapped to values of appropriate types.
+
+    We encode this in an element-by-element style inductive relation:
+    empty states are only well-typed with respect to an empty context,
+    while non-empty states need to map their head atom to a value of the
     appropriate type and their tails must also be well typed.
   *)
 
 Inductive typed_state : context -> state -> Prop :=
 | TS_Empty : typed_state AtomMap.empty AtomMap.empty
-| TS_Elem  : forall x v T st Gamma, 
+| TS_Elem  : forall x v T st Gamma,
     has_type_value v T -> typed_state Gamma st ->
     typed_state ((x,T)::Gamma) ((x,v)::st).
 
 Instance dec_typed_state Gamma st : Dec (typed_state Gamma st).
-Proof. 
+Proof.
 constructor; unfold ssrbool.decidable.
 generalize dependent Gamma.
 induction st; intros; destruct Gamma; solve_sum.
@@ -729,17 +729,17 @@ subst; specialize (IHst Gamma); destruct IHst; solve_sum.
 destruct (dec_has_type_value v T); destruct dec; solve_sum.
 Defined.
 
-(** To write a generator for well typed states given a context [Gamma], 
-    we use the combinator [sequenceGen : list (G A) -> G (list A)], that 
-    receives a list of generators and produces a generator of lists. 
-    This is what Haskell's [sequence] combinator would do for the monad [G]. 
-  
+(** To write a generator for well typed states given a context [Gamma],
+    we use the combinator [sequenceGen : list (G A) -> G (list A)], that
+    receives a list of generators and produces a generator of lists.
+    This is what Haskell's [sequence] combinator would do for the monad [G].
+
     We just need to iterate ([map]) through the context, producing
-    an arbitrary value of the appropriate type for each pair [(x,T)]. The 
+    an arbitrary value of the appropriate type for each pair [(x,T)]. The
     [sequenceGen] combinator will then chain all those generators in sequence,
     producing a generator for well-typed states *)
-    
-Definition gen_typed_state (Gamma : context) : G state := 
+
+Definition gen_typed_state (Gamma : context) : G state :=
   sequenceGen (List.map (fun '(x, T) =>
                            v <- gen_typed_value T;;
                            ret (x, v)) Gamma).
@@ -747,49 +747,49 @@ Definition gen_typed_state (Gamma : context) : G state :=
 (* ################################################################# *)
 (** * Evaluation *)
 
-(** Our evaluation function, takes a state and an expression and returns 
-    an optional value, assuming that the expression has a type 
-    with respect to the state. 
+(** Our evaluation function, takes a state and an expression and returns
+    an optional value, assuming that the expression has a type
+    with respect to the state.
   *)
 
 Fixpoint eval (st : state) (e : exp) : option value :=
   match e with
   | EVar x => AtomMap.get st x
   | ENum n => Some (VNat n)
-  | EPlus e1 e2 => 
-    match eval st e1, eval st e2 with 
+  | EPlus e1 e2 =>
+    match eval st e1, eval st e2 with
     | Some (VNat n1), Some (VNat n2) => Some (VNat (n1 + n2))
     | _, _ => None
-    end 
-  | EMinus e1 e2 => 
-    match eval st e1, eval st e2 with 
+    end
+  | EMinus e1 e2 =>
+    match eval st e1, eval st e2 with
     | Some (VNat n1), Some (VNat n2) => Some (VNat (n1 - n2))
     | _, _ => None
     end
-  | EMult e1 e2 => 
-    match eval st e1, eval st e2 with 
+  | EMult e1 e2 =>
+    match eval st e1, eval st e2 with
     | Some (VNat n1), Some (VNat n2) => Some (VNat (n1 * n2))
     | _, _ => None
     end
   | ETrue       => Some (VBool true  )
   | EFalse      => Some (VBool false )
-  | EEq e1 e2 => 
-    match eval st e1, eval st e2 with 
+  | EEq e1 e2 =>
+    match eval st e1, eval st e2 with
     | Some (VNat n1), Some (VNat n2) => Some (VBool (n1 =? n2))
     | _, _ => None
     end
-  | ELe e1 e2 => 
-    match eval st e1, eval st e2 with 
+  | ELe e1 e2 =>
+    match eval st e1, eval st e2 with
     | Some (VNat n1), Some (VNat n2) => Some (VBool (n1 <? n2))
     | _, _ => None
     end
-  | ENot e => 
-    match eval st e with 
+  | ENot e =>
+    match eval st e with
     | Some (VBool b) => Some (VBool (negb b))
     | _ => None
     end
-  | EAnd e1 e2  => 
-    match eval st e1, eval st e2 with 
+  | EAnd e1 e2  =>
+    match eval st e1, eval st e2 with
 (* Leo: Stupidest bug possible *)
     | Some (VBool b), Some (VNat n2) => Some (VBool (negb b))
 (*    | Some (VBool b1), Some (VBool b2) => Some (VBool (andb b1 b2)) *)
@@ -797,17 +797,17 @@ Fixpoint eval (st : state) (e : exp) : option value :=
     end
   end.
 
-(** Type Soundness states that if we have an expression [e] of a given type [T], 
+(** Type Soundness states that if we have an expression [e] of a given type [T],
     as well as a well-typed state [st], then evaluating [e] in [st] will
     never fail.*)
 
 Definition isNone {A : Type} (m : option A) :=
-  match m with 
+  match m with
   | None => true
   | _ => false
   end.
 
-Conjecture expression_soundness : 
+Conjecture expression_soundness :
   forall Gamma st e T,
     typed_state Gamma st ->
     has_type Gamma e T ->
@@ -815,72 +815,72 @@ Conjecture expression_soundness :
 
 (** To test that property, we construct an appropriate checker *)
 
-Definition expression_soundness_exec := 
-  let num_vars := 4 in 
+Definition expression_soundness_exec :=
+  let num_vars := 4 in
   let top_level_size := 3 in
   forAll (gen_context num_vars)  (fun Gamma =>
   forAll (gen_typed_state Gamma) (fun st =>
-  forAll arbitrary (fun T =>                                    
-  forAll (gen_exp_typed_sized 3 Gamma T) (fun me => 
-  match me with  
+  forAll arbitrary (fun T =>
+  forAll (gen_exp_typed_sized 3 Gamma T) (fun me =>
+  match me with
   | Some e => negb (isNone (eval st e))
   | _ => false
-  end)))).   
+  end)))).
 
 (* QuickChick expression_soundness_exec. *)
 
-(** But where is the bug? :o 
+(** But where is the bug? :o
     We need shrinking. *)
 
 (* ================================================================= *)
 (** ** Shrinking for Expressions *)
 
-(** We not only need to shrink expressions, we need to shrink them 
-    so that their type is preserved! To accomplish that we need to follow 
+(** We not only need to shrink expressions, we need to shrink them
+    so that their type is preserved! To accomplish that we need to follow
     a reverse procedure than with the generators: look at a typing derivation
-    and see what parts of it we can shrink to appropriate types so that 
+    and see what parts of it we can shrink to appropriate types so that
     the entire thing is preserved.
-   
-    For example, to shrink [EPlus e1 e2], we could shrink [e1] or [e2] preserving 
-    their [TNat] type, or shrink to [e1] or [e2] themselves. However, for 
+
+    For example, to shrink [EPlus e1 e2], we could shrink [e1] or [e2] preserving
+    their [TNat] type, or shrink to [e1] or [e2] themselves. However, for
     [EEq e1 e2], we could to shrink [e1] or [e2] again preserving their [TNat]
-    types, but we couldn't shrink to [e1] or [e2] as their type is wrong. 
+    types, but we couldn't shrink to [e1] or [e2] as their type is wrong.
  *)
-   
+
 Fixpoint shrink_exp_typed (T : ty) (e : exp) : list exp :=
-  match e with 
-  | EVar _ => 
-    match T with 
+  match e with
+  | EVar _ =>
+    match T with
     | TNat => [ENum 0]
     | TBool => [ETrue ; EFalse]
     end
   | ENum _ => []
   | ETrue => []
   | EFalse => [ETrue]
-  | EPlus e1 e2 => 
-    e1 :: e2 
+  | EPlus e1 e2 =>
+    e1 :: e2
        :: (List.map (fun e1' => EPlus e1' e2) (shrink_exp_typed T e1))
        ++ (List.map (fun e2' => EPlus e1 e2') (shrink_exp_typed T e2))
-  | EMinus e1 e2 => 
+  | EMinus e1 e2 =>
     e1 :: e2 :: (EPlus e1 e2)
        :: (List.map (fun e1' => EMinus e1' e2) (shrink_exp_typed T e1))
        ++ (List.map (fun e2' => EMinus e1 e2') (shrink_exp_typed T e2))
-  | EMult e1 e2 => 
+  | EMult e1 e2 =>
     e1 :: e2 :: (EPlus e1 e2)
        :: (List.map (fun e1' => EMult e1' e2) (shrink_exp_typed T e1))
        ++ (List.map (fun e2' => EMult e1 e2') (shrink_exp_typed T e2))
-  | EEq e1 e2 => 
-    ETrue :: EFalse 
+  | EEq e1 e2 =>
+    ETrue :: EFalse
        :: (List.map (fun e1' => EEq e1' e2) (shrink_exp_typed TNat e1))
        ++ (List.map (fun e2' => EEq e1 e2') (shrink_exp_typed TNat e2))
-  | ELe e1 e2 => 
+  | ELe e1 e2 =>
     ETrue :: EFalse :: (EEq e1 e2)
        :: (List.map (fun e1' => ELe e1' e2) (shrink_exp_typed TNat e1))
        ++ (List.map (fun e2' => ELe e1 e2') (shrink_exp_typed TNat e2))
-  | ENot e => 
+  | ENot e =>
     ETrue :: EFalse :: e :: (List.map ENot (shrink_exp_typed T e))
-  | EAnd e1 e2 => 
-    ETrue :: EFalse :: e1 :: e2 
+  | EAnd e1 e2 =>
+    ETrue :: EFalse :: e1 :: e2
        :: (List.map (fun e1' => EAnd e1' e2) (shrink_exp_typed TBool e1))
        ++ (List.map (fun e2' => EAnd e1 e2') (shrink_exp_typed TBool e2))
   end.
@@ -888,15 +888,15 @@ Fixpoint shrink_exp_typed (T : ty) (e : exp) : list exp :=
 (** Similarly with generators, we can have a sanity check for our shrinking:
     Given a random expression of a given type, all of the results of [shrink]
     should have the same type. *)
-    
+
 Definition shrink_typed_has_type :=
   let num_vars := 4 in
-  let top_level_size := 3 in 
+  let top_level_size := 3 in
   forAll (gen_context num_vars) (fun Gamma =>
-  forAll arbitrary (fun T =>                                   
+  forAll arbitrary (fun T =>
   forAll (gen_exp_typed_sized top_level_size Gamma T) (fun me =>
-  match me with 
-  | Some e => 
+  match me with
+  | Some e =>
     List.forallb (fun e' => (has_type Gamma e' T)?) (shrink_exp_typed T e)
   | _ => false (* this should NEVER fail *)
   end))).
@@ -910,25 +910,25 @@ Definition shrink_typed_has_type :=
     function. *)
 
 Definition lift_shrink {A : Type} (shr : A -> list A) (m : option A) : list (option A) :=
-  match m with 
+  match m with
   | Some x => List.map Some (shr x)
   | _ => []
   end.
 
-(** Armed with shrinking we can pinpoint the bug in the [EAnd] branch 
+(** Armed with shrinking we can pinpoint the bug in the [EAnd] branch
     and remove the obvious bug. *)
 
-Definition expression_soundness_exec' := 
-  let num_vars := 4 in 
+Definition expression_soundness_exec' :=
+  let num_vars := 4 in
   let top_level_size := 3 in
   forAll (gen_context num_vars)  (fun Gamma =>
   forAll (gen_typed_state Gamma) (fun st =>
-  forAll arbitrary (fun T =>                                    
-  forAllShrink (gen_exp_typed_sized 3 Gamma T) (lift_shrink (shrink_exp_typed T)) (fun me =>  
-  match me with  
+  forAll arbitrary (fun T =>
+  forAllShrink (gen_exp_typed_sized 3 Gamma T) (lift_shrink (shrink_exp_typed T)) (fun me =>
+  match me with
   | Some e => negb (isNone (eval st e))
   | _ => false
-  end)))).   
+  end)))).
 
 (* QuickChick expression_soundness_exec'. *)
 
@@ -968,18 +968,18 @@ Notation "'IFB' c1 'THEN' c2 'ELSE' c3 'FI'" :=
 
 Inductive well_typed_com : context -> com -> Prop :=
   | TSkip : forall Gamma, well_typed_com Gamma CSkip
-  | TAss  : forall Gamma x e T, 
+  | TAss  : forall Gamma x e T,
       bind_in Gamma x T -> has_type Gamma e T ->
       well_typed_com Gamma (CAss x e)
-  | TSeq  : forall Gamma c1 c2, 
+  | TSeq  : forall Gamma c1 c2,
       well_typed_com Gamma c1 -> well_typed_com Gamma c2 ->
       well_typed_com Gamma (CSeq c1 c2)
-  | TIf : forall Gamma b c1 c2, 
+  | TIf : forall Gamma b c1 c2,
       has_type Gamma b TBool ->
       well_typed_com Gamma c1 -> well_typed_com Gamma c2 ->
       well_typed_com Gamma (CIf b c1 c2)
   | TWhile : forall Gamma b c,
-      has_type Gamma b TBool -> well_typed_com Gamma c -> 
+      has_type Gamma b TBool -> well_typed_com Gamma c ->
       well_typed_com Gamma (CWhile b c).
 
 (** Decidable instance for well-typed *)
@@ -987,15 +987,15 @@ Inductive well_typed_com : context -> com -> Prop :=
 (** A couple of theorems to help the decidability proof *)
 
 Theorem bind_deterministic Gamma x (T1 T2 : ty) :
-  bind_in Gamma x T1 -> bind_in Gamma x T2 -> 
+  bind_in Gamma x T1 -> bind_in Gamma x T2 ->
   T1 = T2.
 Proof.
-  destruct T1; destruct T2; intros H1 H2; eauto; 
+  destruct T1; destruct T2; intros H1 H2; eauto;
     inversion H1; inversion H2; congruence.
 Qed.
 
-Theorem has_type_deterministic Gamma e (T1 T2 : ty) : 
-  has_type e Gamma T1 -> has_type e Gamma T2 -> 
+Theorem has_type_deterministic Gamma e (T1 T2 : ty) :
+  has_type e Gamma T1 -> has_type e Gamma T2 ->
   T1 = T2.
 Proof.
   destruct T1; destruct T2; intros H1 H2; eauto;
@@ -1005,8 +1005,8 @@ Proof.
 Qed.
 
 (* More tactic magic *)
-Ltac solve_det := 
-  match goal with 
+Ltac solve_det :=
+  match goal with
   | [ H1 : bind_in _ _ ?T1 ,
       H2 : bind_in _ _ ?T2 |- _ ] =>
     assert (T1 = T2) by (eapply bind_deterministic; eauto)
@@ -1015,14 +1015,14 @@ Ltac solve_det :=
     assert (T1 = T2) by (eapply bind_deterministic; eauto)
   end.
 
-(* We also provide a (brute-force) decidability procedure for well typed 
+(* We also provide a (brute-force) decidability procedure for well typed
    programs *)
 Instance dec_well_typed_com (Gamma : context) (c : com) : Dec (well_typed_com Gamma c) := {}.
 Proof with eauto.
   unfold ssrbool.decidable.
   induction c; solve_sum.
   - destruct (dec_bind_in Gamma t TNat); destruct dec;
-    destruct (dec_has_type e Gamma TNat); destruct dec; 
+    destruct (dec_has_type e Gamma TNat); destruct dec;
     destruct (dec_bind_in Gamma t TBool); destruct dec;
     destruct (dec_has_type e Gamma TBool); destruct dec; solve_sum;
     try solve_det; try congruence;
@@ -1032,7 +1032,7 @@ Proof with eauto.
   - destruct IHc1; destruct IHc2; subst; eauto; solve_sum.
   - destruct IHc1; destruct IHc2; subst; eauto; solve_sum.
     destruct (dec_has_type e Gamma TBool); destruct dec; solve_sum.
-  - destruct IHc; 
+  - destruct IHc;
     destruct (dec_has_type e Gamma TBool); destruct dec; solve_sum.
 Qed.
 
@@ -1041,46 +1041,46 @@ Qed.
 
 (* FILL IN HERE *)
 
-(** To complete the tour of TImp, here is a (buggy?) evaluation function for 
-    commands given a state. To ensure termination, we include an 
-    additional fuel parameter: if that runs out we return [OutOfGas], signifying  
-    that we're not sure if evaluation would have succeeded or failed later. 
+(** To complete the tour of TImp, here is a (buggy?) evaluation function for
+    commands given a state. To ensure termination, we include an
+    additional fuel parameter: if that runs out we return [OutOfGas], signifying
+    that we're not sure if evaluation would have succeeded or failed later.
   *)
-  
-Inductive result := 
+
+Inductive result :=
 | Success : state -> result
-| Fail : result 
-| OutOfGas : result. 
+| Fail : result
+| OutOfGas : result.
 
 (* State monad like fuel, or depth-like? *)
 Fixpoint ceval (fuel : nat) (st : state) (c : com) : result :=
-  match fuel with 
+  match fuel with
   | O => OutOfGas
-  | S fuel' => 
+  | S fuel' =>
     match c with
     | SKIP =>
         Success st
     | x ::= e =>
-        match eval st e with 
+        match eval st e with
         | Some v => Success (AtomMap.set st x v)
-        | _ => Fail 
+        | _ => Fail
         end
     | c1 ;;; c2 =>
-        match ceval fuel' st c1 with 
-        | Success st' =>  ceval fuel' st' c2 
+        match ceval fuel' st c1 with
+        | Success st' =>  ceval fuel' st' c2
         (* Bug : On OutOfGas should out of Gas :
         | r => r
         *)
-        | _ => Fail 
+        | _ => Fail
         end
     | IFB b THEN c1 ELSE c2 FI =>
-      match eval st b with 
+      match eval st b with
       | Some (VBool b) =>
         ceval fuel' st (if b then c1 else c2)
       | _ => Fail
       end
     | WHILE b DO c END =>
-      match eval st b with 
+      match eval st b with
       | Some (VBool b') =>
         if b' then ceval fuel' st (c ;;; WHILE b DO c END) else Success st
       | _ => Fail
@@ -1088,20 +1088,20 @@ Fixpoint ceval (fuel : nat) (st : state) (c : com) : result :=
     end
   end.
 
-Definition isFail r := 
-  match r with 
+Definition isFail r :=
+  match r with
   | Fail => true
   | _ => false
   end.
 
 (** Our type soundness property is that well_typed commands never fail *)
-Conjecture well_typed_state_never_stuck : 
+Conjecture well_typed_state_never_stuck :
   forall Gamma st, typed_state Gamma st ->
   forall c, well_typed_com Gamma c ->
   forall fuel, isFail (ceval fuel st c) = false.
 
-(* Exercise 4: Write a checker for the above property, find any bugs 
+(* Exercise 4: Write a checker for the above property, find any bugs
    and fix them *)
 
-(* FILL IN HERE *)                  
+(* FILL IN HERE *)
 

--- a/qc/Typeclasses.v
+++ b/qc/Typeclasses.v
@@ -16,11 +16,11 @@ Local Open Scope string.
        - [showBool : bool -> string]
        - [showNat : nat -> string]
        - etc.
-    
+
     plus combinators for structured types like [list] and pairs
- 
+
        - [showList : {A : Type} (A -> string) -> (list A) -> string]
-       - [showPair : {A B : Type} (A -> string) -> (B -> string) -> 
+       - [showPair : {A B : Type} (A -> string) -> (B -> string) ->
          A * B -> string]
 
     that take string converters for their element types as arguments.
@@ -85,7 +85,7 @@ Class Show A : Type :=
 (** The [Show] typeclass can be thought of as "classifying" types
     whose values can be converted to strings -- that is, types [A]
     such that we can define a function [show] of type [A -> string].
-    
+
     We can declare that [bool] is such a type by giving an [Instance]
     declaration that witnesses this function: *)
 
@@ -209,7 +209,7 @@ Class Eq A :=
 
 Instance eqBool : Eq bool :=
   {
-    eqb := fun (b c : bool) => 
+    eqb := fun (b c : bool) =>
        match b, c with
          | true, true => true
          | true, false => false
@@ -252,7 +252,7 @@ Instance eqNat : Eq nat :=
 Instance showPair {A B : Type} `{Show A} `{Show B} : Show (A * B) :=
   {|
     show p :=
-      let (a,b) := (p : A * B) in 
+      let (a,b) := (p : A * B) in
         "(" ++ show a ++ "," ++  show b ++ ")"
   |}.
 
@@ -333,7 +333,7 @@ Check Ord.
 (** (The old class [Eq] is sometimes called a "superclass" of [Ord],
     but, again, this terminology is potentially confusing: Try to
     avoid thinking about analogies with object-oriented
-    programming!) *) 
+    programming!) *)
 
 (** When we define instances of [Ord], we just have to implement the
     [le] operation. *)
@@ -394,7 +394,7 @@ Definition max {A: Type} `{Eq A} `{Ord A} (x y : A) : A :=
 (** To enable this behavior for a particular variable, say [A], we
     first declare [A] to be implicitly generalizable: *)
 
-Generalizable Variables A.  
+Generalizable Variables A.
 
 (** By default, Coq only implicitly generalizes variables declared in
     this way, to avoid puzzling behavior in case of typos.  There is
@@ -413,7 +413,7 @@ Definition showOne1 `{Show A} (a : A) : string :=
 
 Print showOne1.
 (* ==>
-    showOne1 = 
+    showOne1 =
       fun (A : Type) (H : Show A) (a : A) => "The value is " ++ show a
            : forall A : Type, Show A -> A -> string
 
@@ -468,9 +468,9 @@ Print showOne1.
 Print showOne2.
 Print showOne3.
 Print showOne4.
-(* ==> 
-    showOne = 
-        fun (A : Type) (H : Show A) (a : A) => 
+(* ==>
+    showOne =
+        fun (A : Type) (H : Show A) (a : A) =>
           "The value is " ++ @show A H a
       : forall A : Type, Show A -> A -> string
 *)
@@ -497,12 +497,12 @@ Definition max1 `{Ord A} (x y : A) :=
 Set Printing Implicit.
 Print max1.
 (* ==>
-     max1 = 
+     max1 =
        fun (A : Type) (H : Eq A) (H0 : @Ord A H) (x y : A) =>
          if @le A H H0 x y then y else x
 
-   : forall (A : Type) (H : Eq A), 
-       @Ord A H -> A -> A -> A    
+   : forall (A : Type) (H : Eq A),
+       @Ord A H -> A -> A -> A
 *)
 
 Check Ord.
@@ -539,8 +539,8 @@ Print implicit_fun.
 (** ... we will need to use @ to actually apply the function: *)
 
 (* Compute (implicit_fun 2 3). *)
-(* ==> 
-    Error: Illegal application (Non-functional construction): 
+(* ==>
+    Error: Illegal application (Non-functional construction):
     The expression "implicit_fun" of type "nat"
     cannot be applied to the term
      "2" : "nat"
@@ -573,9 +573,9 @@ Record Point :=
     }.
 
 (** Internally, this declaration is desugared into a single-field
-    inductive type, roughly like this: 
+    inductive type, roughly like this:
 
-    Inductive Point : Set := 
+    Inductive Point : Set :=
       | Build_Point : nat -> nat -> Point.
 *)
 
@@ -591,7 +591,7 @@ Check (Build_Point 2 4).
 Check {| px := 2; py := 4 |}.
 Check {| py := 4; px := 2 |}.
 
-(** We can also access fields of a record using conventional "dot notation" 
+(** We can also access fields of a record using conventional "dot notation"
     (with slightly clunky concrete syntax): *)
 
 Definition r : Point := {| px := 2; py := 4 |}.
@@ -613,7 +613,7 @@ Record LabeledPoint (A : Type) :=
     type inference!) *)
 
 Check {| lx:=2; ly:=4; label:="hello" |}.
-(* ==> 
+(* ==>
      {| lx := 2; ly := 4; label := "hello" |}
         : LabeledPoint string
 *)
@@ -636,10 +636,10 @@ Check {| lx:=2; ly:=4; label:="hello" |}.
 
 Set Printing All.
 Print Show.
-(* ==> 
-    Record Show (A : Type) : Type := 
+(* ==>
+    Record Show (A : Type) : Type :=
       Build_Show
-        { show : A -> string } 
+        { show : A -> string }
 *)
 Unset Printing All.
 (** (If you run the [Print] command yourself, you'll see that [Show]
@@ -669,12 +669,12 @@ Print showNat.
 Set Printing All.
 Print show.
 (* ==>
-    show = 
+    show =
       fun (A : Type) (Show0 : Show A) =>
         match Show0 with
           | Build_Show _ show => show
         end
-   : forall (A : Type), Show A -> A -> string 
+   : forall (A : Type), Show A -> A -> string
 
    Arguments A, Show are implicit and maximally inserted  *)
 Unset Printing All.
@@ -687,7 +687,7 @@ Unset Printing All.
     typeclasses is the way appropriate instances are automatically
     inferred (and constructed!) during typechecking. *)
 
-(** For example, if we write [show 42], what we actually get is 
+(** For example, if we write [show 42], what we actually get is
     [@show nat showNat 42]: *)
 
 Definition eg42 := show 42.
@@ -785,15 +785,15 @@ Unset Typeclasses Debug.
     sense.
 *)
 
-Class EqDec (A : Type) {H : Eq A} := 
-  { 
-    eqb_eq : forall x y, eqb x y = true <-> x = y 
+Class EqDec (A : Type) {H : Eq A} :=
+  {
+    eqb_eq : forall x y, eqb x y = true <-> x = y
   }.
 
 (** To build an instance of [EqDec], we must now supply an appropriate
     proof. *)
 
-Instance eqdecNat : EqDec nat := 
+Instance eqdecNat : EqDec nat :=
   {
     eqb_eq := Nat.eqb_eq
   }.
@@ -804,7 +804,7 @@ Instance eqdecNat : EqDec nat :=
     will enter proof mode and ask the user to use tactics to construct
     inhabitants for the remaining fields. *)
 
-Instance eqdecBool' : EqDec bool := 
+Instance eqdecBool' : EqDec bool :=
   {
   }.
 Proof.
@@ -830,7 +830,7 @@ Defined.
 Lemma eqb_fact `{EqDec A} : forall (x y z : A),
   eqb x y = true -> eqb y z = true -> x = z.
 Proof.
-  intros x y z Exy Eyz. 
+  intros x y z Exy Eyz.
   rewrite eqb_eq in Exy.
   rewrite eqb_eq in Eyz.
   subst. reflexivity. Qed.
@@ -849,7 +849,7 @@ Proof.
 Require Import Coq.Relations.Relation_Definitions.
 
 Class Reflexive (A : Type) (R : relation A) :=
-  { 
+  {
     reflexivity : forall x, R x x
   }.
 
@@ -860,7 +860,7 @@ Class Transitive (A : Type) (R : relation A) :=
 
 Generalizable Variables z w R.
 
-Lemma trans3 : forall `{Transitive A R}, 
+Lemma trans3 : forall `{Transitive A R},
     `{R x y -> R y z -> R z w -> R x w}.
 Proof.
   intros.
@@ -875,7 +875,7 @@ Class PreOrder (A : Type) (R : relation A) :=
     [Reflexive] and [Transitive] relation, so that, any time a
     reflexive relation is needed, a preorder can be used instead. *)
 
-Lemma trans3_pre : forall `{PreOrder A R}, 
+Lemma trans3_pre : forall `{PreOrder A R},
     `{R x y -> R y z -> R z w -> R x w}.
 Proof. intros. eapply trans3; eassumption. Defined.
 
@@ -964,7 +964,7 @@ Fixpoint All {T : Type} (P : T -> Prop) (l : list T) : Prop :=
     decidable proposition [P] into a boolean expression. *)
 
 Notation "P '?'" :=
-  (match (@dec P _) with 
+  (match (@dec P _) with
    | left _ => true
    | right _ => false
    end)
@@ -1029,7 +1029,7 @@ Open Scope monad_scope.
 (** The main definition provided by this library is the following typeclass:
 
     Class Monad (M : Type -> Type) : Type :=
-       { 
+       {
          ret : forall {T : Type}, T -> M T ;
          bind : forall {T U : Type}, M T -> (T -> M U) -> M U
        }.
@@ -1098,14 +1098,14 @@ Definition liftM
 Definition liftM2
             {m : Type -> Type}
             {M : Monad m}
-            {T U V : Type} (f : T -> U -> V) 
+            {T U V : Type} (f : T -> U -> V)
           : m T -> m U -> m V :=
     fun x y => bind x (fun x => liftM (f x) y).
 
 Definition liftM3
             {m : Type -> Type}
             {M : Monad m}
-            {T U V W : Type} (f : T -> U -> V -> W) 
+            {T U V W : Type} (f : T -> U -> V -> W)
           : m T -> m U -> m V -> m W :=
     fun x y z => bind x (fun x => liftM2 (f x) y z).
 
@@ -1169,7 +1169,7 @@ Definition foo x := if eqb x x then "Of course" else "Impossible".
 Fail Check (foo bool).
 (* ==>
      The command has indeed failed with message:
-     The term "bool" has type "Set" while it is expected 
+     The term "bool" has type "Set" while it is expected
      to have type "bool -> bool".    *)
 
 (** Huh?! *)
@@ -1222,7 +1222,7 @@ Instance baz2 : Show baz :=
   }.
 
 Compute (show (Baz 42)).
-(* ==> 
+(* ==>
      = "[42 is a Baz]"
      : string   *)
 
@@ -1239,7 +1239,7 @@ Compute (show (Baz 42)).
     two given instances overlap.) *)
 
 (** One way to deal with overlapping instances is to "curate" the hint
-    database by explicitly adding and removing specific instances.  
+    database by explicitly adding and removing specific instances.
 
     To remove things, use [Remove Hints]: *)
 
@@ -1252,7 +1252,7 @@ Remove Hints baz1 baz2 : typeclass_instances.
 
 Existing Instance baz1.
 Compute (show (Baz 42)).
-(* ==> 
+(* ==>
      = "Baz: 42"
      : string    *)
 
@@ -1278,7 +1278,7 @@ Instance baz4 : Show baz | 3 :=
   }.
 
 Compute (show (Baz 42)).
-(* ==> 
+(* ==>
      = "{{{ Use me first!  42}}}"
      : string  *)
 
@@ -1290,7 +1290,7 @@ Compute (show (Baz 42)).
 
 Existing Instance baz1 | 0.
 Compute (show (Baz 42)).
-(* ==> 
+(* ==>
      = "Baz: 42"
      : string    *)
 
@@ -1311,7 +1311,7 @@ Inductive bar :=
 Fail Definition eqBar :=
   eqb (Bar 42) (Bar 43).
 
-(* ===> 
+(* ===>
     The command has indeed failed with message:
     Unable to satisfy the following constraints:
 
@@ -1412,7 +1412,7 @@ Compute e3.
     a state of great peril: If we happen to ask for an instance that
     doesn't exist, the search procedure will diverge. *)
 
-(* 
+(*
 Definition e4 : list nat := mymap false.
 *)
 
@@ -1504,9 +1504,9 @@ Definition e4 : list nat := mymap false.
 (* ================================================================= *)
 (** ** John Wiegley *)
 
-(** One thing that always gets me is that overlapping instances are 
+(** One thing that always gets me is that overlapping instances are
     easy to write with no warning from Coq (unlike Haskell, which
-    ensures that resolution always pick a single instance). This 
+    ensures that resolution always pick a single instance). This
     requires me to often use:
 
    Typeclasses eauto := debug.
@@ -1514,7 +1514,7 @@ Definition e4 : list nat := mymap false.
    and switch to my *coq* buffer to see which lookup did not resolve to the
    instance I was expecting. This is usually fixed by one of two things:
 
-      - Change the "priority" of the overlapping instance (something we 
+      - Change the "priority" of the overlapping instance (something we
         cannot do in Haskell).
       - Change the Instance to a Definition -- which I can still use it as an
         explicitly passed dictionary, but this removes it from resolution.
@@ -1525,10 +1525,10 @@ Definition e4 : list nat := mymap false.
     this would be an error, but in Coq it just resolves to whatever
     the last globally defined instance was.
 
-    For example, say I write a function that uses a functor, but forget 
+    For example, say I write a function that uses a functor, but forget
     to mention the functor:
 
-   Definition foo (C D : Category) (x y : C) (f : x ~> y) 
+   Definition foo (C D : Category) (x y : C) (f : x ~> y)
               : fobj x ~> fobj y :=
      fmap f.
 
@@ -1568,7 +1568,7 @@ Definition e4 : list nat := mymap false.
      oops_is_baz :> Baz
    }.
 
-    [Oops] refers to two [Foos], and I need explicit evidence to know when 
+    [Oops] refers to two [Foos], and I need explicit evidence to know when
     they are the same [Foo]. I work around this using indices:
 
    Class Foo := {
@@ -1603,7 +1603,7 @@ Definition e4 : list nat := mymap false.
    --------------------
    @method F A = @method F B
 
-    You can't apply here without simplying in H. However, what you see at 
+    You can't apply here without simplying in H. However, what you see at
     first is:
 
    A, B : Type
@@ -1695,7 +1695,7 @@ Definition e4 : list nat := mymap false.
     The original paper on typeclasses In Coq:
       - Matthieu Sozeau and Nicolas Oury. First-Class Type
         Classes. TPHOLs 2008.
-        https://link.springer.com/chapter/10.1007%%2F978-3-540-71067-7_23 
+        https://link.springer.com/chapter/10.1007%%2F978-3-540-71067-7_23
 
     Sources for this tutorial:
      - Coq Reference Manual:

--- a/vminus/Atom.v
+++ b/vminus/Atom.v
@@ -8,8 +8,8 @@ Require Import QuickChick.QuickChick.
 (* ################################################################# *)
 (** * The [ATOM] signature *)
 
-(** This interface defines a type of atoms with: 
-      - a _decidable equality_ 
+(** This interface defines a type of atoms with:
+      - a _decidable equality_
       - a way of generating _fresh_ atoms
 *)
 Module Type ATOM <: UsualDecidableType.
@@ -33,7 +33,7 @@ Module Atom : ATOM.
 
   Definition t := nat.
   Definition eq_dec := eq_nat_dec.
-  
+
   Fixpoint max_elt (al:list t) : t :=
     match al with
       | nil => 0
@@ -50,8 +50,8 @@ Module Atom : ATOM.
       inversion H; subst; simpl. apply Nat.le_max_l.
       eapply le_trans; auto with arith. (* apply Nat.le_max_r. *)
   Qed.
-    
-  Lemma fresh_not_in : forall l, 
+
+  Lemma fresh_not_in : forall l,
     ~ In (fresh l) l.
   Proof.
     unfold fresh, not. intros l Hin.
@@ -62,7 +62,7 @@ Module Atom : ATOM.
   Include HasUsualEq <+ UsualIsEq.
 
   Definition nat_of (a : nat) := a.
-  
+
 End Atom.
 
 (* Automatically unfold Atom.eq *)

--- a/vminus/AtomGen.v
+++ b/vminus/AtomGen.v
@@ -16,7 +16,7 @@ Fixpoint get_fresh_atoms n l :=
   end.
 
 Definition fresh_store : list Atom.t := get_fresh_atoms 100 [].
-Definition gen_fresh (atom_store : list Atom.t) : G Atom.t := 
+Definition gen_fresh (atom_store : list Atom.t) : G Atom.t :=
   oneof (returnGen (Atom.fresh [])) (List.map returnGen atom_store).
 
 Fixpoint index_of_atom_in_list (a : Atom.t) (l : list Atom.t) : option nat :=

--- a/vminus/CFG.v
+++ b/vminus/CFG.v
@@ -17,7 +17,7 @@ Require Import Vminus.Vminus.
     graph).
 
     The program points are themselves organized into _basic blocks_.
-    A basic block consists of a non-empty sequence of program points 
+    A basic block consists of a non-empty sequence of program points
     ending in a terminator instruction.
  *)
 
@@ -80,8 +80,8 @@ Definition entry_of_pc (p:pc)  : pc := block_entry (fst p).
     representation.)
  *)
 
-(** 
-    In this interface, we establish the basic syntactic properties of 
+(**
+    In this interface, we establish the basic syntactic properties of
     control-flow-graphs:
 
     - A CFG [g] is a (partial) function from program points to instructions.
@@ -90,7 +90,7 @@ Definition entry_of_pc (p:pc)  : pc := block_entry (fst p).
     - Each basic block consists of a contiguous sequence of program points,
       ending in a terminator.
 
-    We will impose stronger well-formedness constraints (i.e. the SSA 
+    We will impose stronger well-formedness constraints (i.e. the SSA
     conditions) on CFGs later.
 *)
 
@@ -130,19 +130,19 @@ Module Type CFG.
 
   Axiom insn_at_pc_func : forall g, wf_cfg g ->
     functional (insn_at_pc g).
-  
+
   (** Executable specification: *)
-  
+
   Parameter fetch : cfg -> pc -> option insn.
 
   (** Correspondence of the two specs: *)
-  
+
   Axiom insn_at_pc_fetch :
     forall g pc i, wf_cfg g ->
               insn_at_pc g pc i <-> fetch g pc = Some i.
 
   (** Each [pc] defines a unique [uid] *)
-  
+
   Definition uid_at_pc (g:cfg) (p:pc) (uid:uid) : Prop :=
     exists c, insn_at_pc g p (uid, c).
 
@@ -151,7 +151,7 @@ Module Type CFG.
 
   Axiom uid_at_pc_func : forall g, wf_cfg g ->
     functional (uid_at_pc g).
-  
+
   Axiom pc_at_uid_inj : forall g, wf_cfg g ->
                              injective (fun x p => uid_at_pc g p x).
 
@@ -161,14 +161,14 @@ Module Type CFG.
     insn_at_pc g pc (id2, c2) ->
     id1 = id2.
 
-  
+
   (** If [g] is well-formed, each of its program points
-      maps to an instruction. *)  
-  
+      maps to an instruction. *)
+
   Axiom wf_pc_insn : forall g, wf_cfg g ->
     forall p, wf_pc g p -> exists i, insn_at_pc g p i.
 
-  
+
   (** *** Block properties *)
 
   (** There is an instruction in the entry block. *)

--- a/vminus/Classes.v
+++ b/vminus/Classes.v
@@ -13,7 +13,7 @@ Set Contextual Implicit.
 Global Generalizable All Variables.
 Global Set Automatic Coercions Import.
 From Coq Require Export Morphisms RelationClasses Setoid.
-Require Import List Bool String Utf8. 
+Require Import List Bool String Utf8.
 Export ListNotations.
 From Coq.Program Require Export Basics Syntax.
 
@@ -44,8 +44,8 @@ Class Equiv A := equiv: relation A.
 Infix "≡" := equiv (at level 70, no associativity).
 Notation "(≡)" := equiv (only parsing).
 Notation "( X ≡)" := (equiv X) (only parsing).
-Notation "(≡ X )" := (λ Y, Y ≡ X) (only parsing). 
-Notation "(≢)" := (λ X Y, ¬X ≡ Y) (only parsing). 
+Notation "(≡ X )" := (λ Y, Y ≡ X) (only parsing).
+Notation "(≢)" := (λ X Y, ¬X ≡ Y) (only parsing).
 Notation "X ≢ Y":= (¬X ≡ Y) (at level 70, no associativity).
 Notation "( X ≢)" := (λ Y, X ≢ Y) (only parsing).
 Notation "(≢ X )" := (λ Y, Y ≢ X) (only parsing).
@@ -65,7 +65,7 @@ Class LeibnizEquiv A `{Equiv A} := leibniz_equiv x y : x ≡ y → x = y.
 Lemma leibniz_equiv_iff `{LeibnizEquiv A, !Reflexive (@equiv A _)} (x y : A) :
   x ≡ y ↔ x = y.
 Proof. split. apply leibniz_equiv. intros ->; reflexivity. Qed.
- 
+
 Ltac fold_leibniz := repeat
   match goal with
   | H : context [ @equiv ?A _ _ _ ] |- _ =>
@@ -154,7 +154,7 @@ Defined.
 Instance eq_dec_option {A} `(EA:eq_dec A) : eq_dec (option A).
 Proof.
   decide_eq_dec.
-Defined.  
+Defined.
 
 Instance eq_dec_list {A} `(EA:eq_dec A) : eq_dec (list A).
 Proof.
@@ -193,7 +193,7 @@ Proof.
   split.
   - apply List.map_id.
   - apply List.map_map.
-Defined. (* CHKoh: Originally Qed. *)    
+Defined. (* CHKoh: Originally Qed. *)
 
 (* ================================================================= *)
 (** ** Monads ------------------------------------------------------------------- *)
@@ -255,7 +255,7 @@ Definition map_monad `{Monad F} {A B} (f:A -> F B) (l:list A) : F (list B) :=
       | a::l' =>
         'b <- f a;
         'bs <- loop l';
-        mret (b::bs)  
+        mret (b::bs)
       end
   in loop l.
 
@@ -264,7 +264,7 @@ Next Obligation.
   split.
   - intros A X. exact (Some X).
   - intros A B X X0.  destruct X. apply X0. exact a. exact None.
-Defined.    
+Defined.
 
 Program Instance option_monad_eq_laws : (@MonadLaws option) _ _ _ _ _.
 Next Obligation.
@@ -272,14 +272,14 @@ Next Obligation.
 Defined.
 Next Obligation.
   destruct a; try reflexivity.
-Defined.  
+Defined.
 
 Program Instance list_monad : (@Monad list) list_functor := _.
 Next Obligation.
   split.
   - intros A X. exact ([X]).
   - intros A B. exact (fun l f => flat_map f l).
-Defined.    
+Defined.
 
 Program Instance list_monad_eq_laws : (@MonadLaws list) _ _ _ _ _.
 Next Obligation.
@@ -334,7 +334,7 @@ Next Obligation.
 Defined.
 Next Obligation.
   destruct a; try reflexivity.
-Defined.  
+Defined.
 
 (* Continuations ------------------------------------------------------------ *)
 
@@ -375,7 +375,7 @@ Definition st_ret {M A} : A -> ST M A := fun (x:A) => fun (m: M) => (m, x).
 Hint Unfold st_ret.
 
 Definition st_bind {M A B} : (ST M A) -> (A -> ST M B) -> ST M B :=
-  fun s => fun f => fun m => let (m', x) := s m in f x m'.            
+  fun s => fun f => fun m => let (m', x) := s m in f x m'.
 Hint Unfold st_bind.
 
 Instance st_functor {M} : (@Functor (ST M)) := (@st_map M).
@@ -456,7 +456,7 @@ Instance string_of_bool : StringOf bool := fun (b:bool) => if b then "true" else
 
 Instance string_of_pair {A B} `(SA:StringOf A) `(SB:StringOf B) : StringOf (A * B)%type :=
   fun p => "(" ++ string_of (fst p) ++ ", " ++ string_of (snd p) ++ ")".
-  
+
 Instance string_of_option {A} `(SA:StringOf A) : StringOf (option A) :=
   fun opt => match opt with None => "None" | Some x => "Some " ++ (string_of x) end.
 
@@ -489,7 +489,7 @@ Definition digit_to_string (x:Z) : string :=
 Fixpoint to_string_b10' fuel (x:Z) : string :=
   match fuel with
   | 0 => "ERR: not enough fuel"
-  | S f => 
+  | S f =>
     match x with
     | Z0 => "0"
     | _ => let '(q,r) := (Z.div_eucl x 10) in

--- a/vminus/Compiler.v
+++ b/vminus/Compiler.v
@@ -12,7 +12,7 @@
 (* ################################################################# *)
 (** * Imp to Vminus Compiler *)
 
-(** Imports, instantiated with the list implementation of 
+(** Imports, instantiated with the list implementation of
     control-flow graphs. *)
 
 Require Import List.
@@ -51,7 +51,7 @@ Definition strun {A:Set} (m:ectmon A) (l:list uid) : A :=
 Definition comp_bop (b:bop) (e1 e2: ectmon (val * list insn)) : ectmon (val * list insn) :=
   '(v1, c1) <- e1;
   '(v2, c2) <- e2;
-  'r <- fresh; 
+  'r <- fresh;
   mret (val_uid r, (c1 ++ c2 ++ [(r, cmd_bop b v1 v2)])).
 
 (** Compile an arithmetic expression. *)
@@ -92,8 +92,8 @@ Fixpoint comp_bexp (b:bexp) : ectmon (val * list insn) :=
 Definition comp_store (a:aexp) (v:addr) (lr:lbl) : ectmon (list insn) :=
   'x <- fresh;
   'y <- fresh;
-  '(i, is) <- comp_aexp a; 
-  mret (is ++ [ (x, cmd_store v i); 
+  '(i, is) <- comp_aexp a;
+  mret (is ++ [ (x, cmd_store v i);
                (y, cmd_tmn (tmn_jmp lr)) ]).
 
 Definition comp_cond (b:bexp) (l1 l2:lbl) : ectmon (list insn) :=
@@ -115,7 +115,7 @@ Notation ctmon := (ST cstate).
 Definition fresh_lbl : ctmon lbl :=
   fun cs =>
   let '(ls, is, bs) := cs in
-  let l := Lbl.fresh ls in 
+  let l := Lbl.fresh ls in
   (l::ls, is, update bs l [], l).
 
 Definition raise_ectmon {T} (ec:ectmon T) : ctmon T :=
@@ -130,14 +130,14 @@ Definition add_insns (l:lbl) (b:list insn) : ctmon unit :=
   (ls, is, update cfg l b, tt).
 
 (** The input [lr] is the label of the block to which
-    control should return after the command is done. 
+    control should return after the command is done.
     The output is the label of the entry block for the
     command. *)
 
 Fixpoint comp_com (c:Imp.com) (lr:lbl) : ctmon lbl :=
   match c with
     | CSkip => mret lr
-    | CAss i a => 
+    | CAss i a =>
         'l <- fresh_lbl;
         'b <- raise_ectmon (comp_store a i lr);
         '_ <- add_insns l b;
@@ -151,7 +151,7 @@ Fixpoint comp_com (c:Imp.com) (lr:lbl) : ctmon lbl :=
         'b  <- raise_ectmon (comp_cond b l1 l2);
         '_  <- add_insns lh b;
         mret lh
-    | CWhile b c => 
+    | CWhile b c =>
         'lh <- fresh_lbl;
         'lb <- comp_com c lh;
         'b  <- raise_ectmon (comp_cond b lb lr);

--- a/vminus/CompilerProp.v
+++ b/vminus/CompilerProp.v
@@ -25,10 +25,10 @@ Unset Printing Records.
 (* ================================================================= *)
 (** ** Correspondence between concrete and abstract CFGs. *)
 
-(** Asserts that the instruction sequence found at program point p in 
+(** Asserts that the instruction sequence found at program point p in
     the control-flow graph g is exactly the list [is]. *)
 
-Fixpoint insns_at_pc (g:ListCFG.t) (p:pc) (is:list insn) : Prop := 
+Fixpoint insns_at_pc (g:ListCFG.t) (p:pc) (is:list insn) : Prop :=
   match is with
     | nil => True
     | i :: is' => ListCFG.insn_at_pc g p i /\ insns_at_pc g (incr_pc p) is'
@@ -63,7 +63,7 @@ Qed.
 (** ** Auxiliary definitions. *)
 
 Definition ids_preserved (cs:list uid) (st st':state) : Prop :=
-  forall uid n, In uid cs -> 
+  forall uid n, In uid cs ->
     st_loc st uid = Some n -> st_loc st' uid = Some n.
 
 Definition good_return (cs:list uid) (v:val) : Prop :=
@@ -99,7 +99,7 @@ Lemma comp_bop_correct : forall b comp1 comp2 eval1 eval2
     comp_correct (comp_bop b comp1 comp2)
                  (fun m => bop_denote b (eval1 m) (eval2 m)).
 Proof.
-  unfold comp_correct. 
+  unfold comp_correct.
   intros b comp1 comp2 eval1 eval2.
   intros until v. intros Hcomp Hinsns.
 
@@ -111,12 +111,12 @@ Proof.
 
   subst.
   repeat rewrite <- app_assoc in Hinsns.
-  eelim IHa1; [| eauto ..]. 
+  eelim IHa1; [| eauto ..].
   intros st1 (Hinv1 & His1 & Hstep1 & Hpres1 & Hret1 & Hincr1 & Heval1).
-  eelim IHa2; [| eauto ..]. 
+  eelim IHa2; [| eauto ..].
   intros st2 (Hinv2 & His2 & Hstep2 & Hpres2 & Hret2 & Hincr2 & Heval2).
   clear IHa1 IHa2.
-  
+
   rename st2 into st2'; set (st2:=st2') in *; destruct st2'.
   eexists {| st_pc  := incr_pc (st_pc st2);
              st_loc := Locals.update (st_loc st2) (Uid.fresh cs2) _ |}. simpl.
@@ -129,12 +129,12 @@ Proof.
 
   (* star (Opsem.step g) *)
   split. eapply star_trans; eauto. eapply star_trans; eauto.
-    eapply star_one. eapply step_bop. inversion His2; eauto.  
-    unfold eval_bop. simpl in Heval2. rewrite Heval2. 
+    eapply star_one. eapply step_bop. inversion His2; eauto.
+    unfold eval_bop. simpl in Heval2. rewrite Heval2.
     replace (eval_val st_loc0 _) with (Some (eval1 (st_mem st))).
-    reflexivity. symmetry. 
+    reflexivity. symmetry.
 
-    destruct rl1; auto. simpl. 
+    destruct rl1; auto. simpl.
     unfold good_return in *.
     rename t into t0.
     assert (In t0 cs1). apply Hret1; auto.
@@ -151,12 +151,12 @@ Proof.
   split. red. intros uid' Hid. injection Hid; inversion Hc2. left; auto.
 
   (* ctx_incr *)
-  split. transitivity cs1; auto. transitivity cs2; auto. 
+  split. transitivity cs1; auto. transitivity cs2; auto.
   unfold ctx_incr. inversion Hc2; intros. right; auto.
 
   (* eval_val *)
   simpl. rewrite Locals.update_eq.
-  replace (st_mem st1) with (st_mem st). subst. reflexivity. 
+  replace (st_mem st1) with (st_mem st). subst. reflexivity.
   inversion Hinv1; auto. reflexivity.
 Qed.
 
@@ -168,12 +168,12 @@ Proof.
   induction a; [ | | eapply comp_bop_correct; auto ..].
 
   - (* Case "ANum". *)
-  unfold comp_correct; intros. inversion H; subst; clear H. 
+  unfold comp_correct; intros. inversion H; subst; clear H.
   exists st. repeat split; try red; auto using star_refl. discriminate.
 
   - (* Case "AId". *)
   unfold comp_correct. intros cs cs' g st is k v Hcomp Hinsns.
-  simpl in Hcomp. 
+  simpl in Hcomp.
   destruct (fresh cs) as [cs1 idr] eqn:Hc.
   inversion Hcomp. clear Hcomp. subst.
 
@@ -186,7 +186,7 @@ Proof.
   inversion Hinsns; eauto.
   simpl in *.
   unfold fresh in Hc. inversion Hc. apply H.
-  split. red; simpl; intros. rewrite Locals.update_neq; auto. 
+  split. red; simpl; intros. rewrite Locals.update_neq; auto.
     inversion Hc. contradict H. rewrite <- H. apply Uid.fresh_not_in.
   split. red. intros. inversion Hc. injection H; intro. subst idr uid. left; auto.
   split. inversion Hc; red; intuition.
@@ -201,11 +201,11 @@ Proof.
   induction b.
 
   - (* Case "BTrue". *)
-  unfold comp_correct; intros. inversion H; subst; clear H. 
+  unfold comp_correct; intros. inversion H; subst; clear H.
   exists st; repeat split; try red; auto using star_refl. discriminate.
 
   - (* Case "BFalse". *)
-  unfold comp_correct; intros. inversion H; subst; clear H. 
+  unfold comp_correct; intros. inversion H; subst; clear H.
   exists st; repeat split; try red; auto using star_refl. discriminate.
 
   - (* Case "BEq". *)
@@ -226,24 +226,24 @@ Proof.
   - (* Case "BAnd". *)
   simpl. evar (SPEC : mem -> nat). replace (fun (m:mem) => b2n _) with SPEC.
   subst SPEC. apply (comp_bop_correct bop_and); eauto.
-  subst SPEC. apply functional_extensionality. intro. 
+  subst SPEC. apply functional_extensionality. intro.
   simpl. destruct (beval b1 x), (beval b2 x); auto.
 Qed.
 
 
 (**
-  - First we define some helper definitions for compiling assignments and 
+  - First we define some helper definitions for compiling assignments and
     conditionals.
     - To simplify the simulation: each store is compiled to its own basic block.
   - Then we define the command compilation context as a state monad.
     - Generate fresh uids (like the [ectmon])
-    - Generate fresh block labels 
+    - Generate fresh block labels
     - Add instructions to the (partial) CFG
   - Then we define the translation of commands (recursively).
 *)
 
 
-Lemma comp_store_correct : 
+Lemma comp_store_correct :
   forall g a v le lr cs st,
   insns_at_pc g (block_entry le) (strun (comp_store a v lr) cs) ->
   st_pc st = (block_entry le) ->
@@ -257,14 +257,14 @@ Proof.
   match type of H with context[let (_,_) := ?x in _] => destruct x eqn:Hc end.
   destruct p as [x is].
   simpl in H. symmetry in Hc.
-  
+
   rewrite <- H0 in H.
   eelim (comp_aexp_correct a); eauto.
   intros st' H'. decompose [and] H'; clear H'.
   rename st' into st''. set (st' := st'') in *. destruct st''.
 
   eexists.
-  split. eapply plus_star_trans'. eauto. 
+  split. eapply plus_star_trans'. eauto.
   eapply plus_left. eapply step_store. apply H3. eauto.
   eapply star_step. eapply step_tmn. inversion H3. apply H9.
   reflexivity.
@@ -295,13 +295,13 @@ Proof.
   rename st' into st''. set (st' := st'') in *. destruct st''.
 
   eexists.
-  split. eapply plus_star_trans'. eauto. 
-  eapply plus_one. eapply step_tmn. 
+  split. eapply plus_star_trans'. eauto.
+  eapply plus_one. eapply step_tmn.
   apply H3. simpl in *. rewrite H8. reflexivity.
   simpl. split; auto.
   destruct (beval b (st_mem st)); simpl; auto.
 Qed.
-  
+
 
 (* ================================================================= *)
 (* ** Compiling Commands *)
@@ -317,7 +317,7 @@ Notation ctmon := (ST cstate).
 Definition fresh_lbl : ctmon lbl :=
   fun cs =>
   let '(ls, is, bs) := cs in
-  let l := Lbl.fresh ls in 
+  let l := Lbl.fresh ls in
   (l::ls, is, ListCFG.update bs l [], l).
 
 Definition raise_ectmon {T} (ec:ectmon T) : ctmon T :=
@@ -387,13 +387,13 @@ Lemma simulation_step' :
     match_states g r (c', mem') st'.
 Proof.
   intros. generalize dependent st. revert r.
-  
+
   dependent induction H; intros;
   inversion H0 as [? ? ? ? H']; inversion H'; subst.
 
   - (* Case "S_Ass". *)
   eapply comp_store_correct in H6 as [st' [? [? ?]]]; eauto.
-  eexists. split. apply plus_star. apply H1. econstructor; eauto. apply MC_Skip. 
+  eexists. split. apply plus_star. apply H1. econstructor; eauto. apply MC_Skip.
 
   - (* Case "S_Seq". *)
     specialize (IHstep c1 c1' (st_mem st) mem').
@@ -402,9 +402,9 @@ Proof.
     lapply K.
     intros [st' [? ?]].
     exists st'. split; auto.
-    inversion H3. 
+    inversion H3.
     econstructor; eauto. econstructor; eauto.
-    econstructor; eauto.  
+    econstructor; eauto.
 
   - (* Case "S_SeqSkip". *)
   exists st. split. apply star_refl.
@@ -413,16 +413,16 @@ Proof.
 
   - (* Case "S_IfTrue". *)
   eapply comp_cond_correct in H14 as [st' [? [? ?]]].
-  exists st'. split. apply plus_star; eauto. econstructor. 
+  exists st'. split. apply plus_star; eauto. econstructor.
   eauto. rewrite H in H3. auto. symmetry; auto. auto.
 
   - (* Case "S_IfFalse". *)
   eapply comp_cond_correct in H14 as [st' [? [? ?]]].
-  exists st'. split. apply plus_star; eauto. econstructor. 
+  exists st'. split. apply plus_star; eauto. econstructor.
   eauto. rewrite H in H3. auto. symmetry; auto. auto.
 
   - (* Case "S_While". *)
-  exists st. split. apply star_refl. 
+  exists st. split. apply star_refl.
   econstructor; eauto. eapply MC_If; eauto.
   econstructor; eauto. apply MC_Skip; eauto.
 Qed.
@@ -431,10 +431,10 @@ Qed.
 (** * Stuttering *)
 
 (** The proof above goes through, but does not ensure that if the
-    source program diverges the compiled program does not go wrong! 
+    source program diverges the compiled program does not go wrong!
 
     To fix it, we need to ensure that there is no "infinite stuttering"
-    in which the source program takes an infinite number of steps while 
+    in which the source program takes an infinite number of steps while
     the target terminates (or gets stuck).
 *)
 
@@ -471,7 +471,7 @@ Lemma com_size_seq : forall c1 c1' c2,
   com_size c1' < com_size c1 ->
   com_size (c1';; c2) < com_size (c1;; c2).
 Proof.
-  unfold com_size; destruct c1, c1'; 
+  unfold com_size; destruct c1, c1';
   try solve [simpl; intros; omega].
 Qed.
 
@@ -480,14 +480,14 @@ Lemma com_size_seqskip : forall c,
 Proof.
   unfold com_size; destruct c;
   try solve [simpl; try match goal with
-                        | |- context[while_head ?X] => 
+                        | |- context[while_head ?X] =>
                              pose proof (while_head_bound X)
                         end; intros; omega].
 Qed.
 
 
 (* lift to states *)
-Definition imp_size (st:com * mem) : nat := 
+Definition imp_size (st:com * mem) : nat :=
   let (c, _) := st in com_size c.
 
 
@@ -508,38 +508,38 @@ Lemma transl_sim_step_final :
     match_states g r imp_st' vmn_st'.
 Proof.
   intros. generalize dependent vmn_st. revert r.
-  
+
   dependent induction H; intros r vmn_st Hst;
   inversion Hst as [? ? ? ? Hcfg]; inversion Hcfg; subst.
 
   - (* Case "S_Ass". *)
   eapply comp_store_correct in H6 as [st' [? [? ?]]]; eauto.
   eexists. split; eauto. econstructor; eauto.
-  
+
   - (* Case "S_Seq". *)
   specialize (IHstep l2 vmn_st).
-  lapply IHstep. intros [vmn_st' [? ?]]. exists vmn_st'. split. 
-  simpl in *; intuition. inversion H2; subst. 
+  lapply IHstep. intros [vmn_st' [? ?]]. exists vmn_st'. split.
+  simpl in *; intuition. inversion H2; subst.
   econstructor; eauto. econstructor; eauto.
 
   - (* Case "S_SeqSkip". *)
-  exists vmn_st. split. right. 
-  split. apply star_refl. unfold imp_size. 
+  exists vmn_st. split. right.
+  split. apply star_refl. unfold imp_size.
   simpl; intuition. inversion H7; subst. econstructor; eauto.
 
   - (* Case "S_IfTrue". *)
   eapply comp_cond_correct in H13 as [st' [? [? ?]]]; eauto.
-  exists st'. split; eauto. econstructor; eauto. 
-  rewrite H in H2; auto. 
+  exists st'. split; eauto. econstructor; eauto.
+  rewrite H in H2; auto.
 
   - (* Case "S_IfFalse". *)
   eapply comp_cond_correct in H13 as [st' [? [? ?]]]; eauto.
-  exists st'. split; eauto. econstructor; eauto.  
-  rewrite H in H2; auto. 
+  exists st'. split; eauto. econstructor; eauto.
+  rewrite H in H2; auto.
 
   - (* Case "S_While". *)
-  exists vmn_st. split. right; intuition. apply star_refl. 
-  econstructor; eauto. 
+  exists vmn_st. split. right; intuition. apply star_refl.
+  econstructor; eauto.
 Qed.
 
 (** Is this enough? *)
@@ -583,7 +583,7 @@ Qed.
 (** Compilation only "extends" the compilation state:
     - Uids and labels change only monotonically.
     - Compilation never removes code.
-  *) 
+  *)
 
 Inductive cstate_incr : cstate -> cstate -> Prop :=
   cstate_incr_intro : forall ls ls' ids ids' g g',
@@ -605,7 +605,7 @@ Inductive cstate_incr_strong : cstate -> cstate -> Prop :=
 
 Instance cstate_incr_strong_trans : Transitive cstate_incr_strong.
 Proof.
-  red. inversion 1. inversion 1. subst. constructor. 
+  red. inversion 1. inversion 1. subst. constructor.
   auto. intros. transitivity (ListCFG.lookup g' l); eauto.
 Qed.
 
@@ -628,7 +628,7 @@ Proof.
 Qed.
 
 
-Lemma ectmon_incr_strong : 
+Lemma ectmon_incr_strong :
   forall (A:Type) (m:ectmon A) (r:A) cs cs' ,
   raise_ectmon m cs = (cs', r) ->
   cstate_incr_strong cs cs'.
@@ -636,7 +636,7 @@ Proof.
   destruct cs as [[? ?] ?], cs' as [[? ?] ?].
   inversion 1.
   destruct (m l0). inversion H1; subst; clear H1.
-  constructor; auto; intros. 
+  constructor; auto; intros.
 Qed.
 
 
@@ -668,7 +668,7 @@ Ltac bind_step H :=
 Ltac compile :=
   repeat
     match goal with
-    | [ x : Compiler.cstate |- _] => destruct x as [[?lbls ?ids] ?bs] 
+    | [ x : Compiler.cstate |- _] => destruct x as [[?lbls ?ids] ?bs]
 (*    | [ H : context[Compiler.add_insns _ _ _] |- _ ] => simpl in H *)
     | [ H : context[let (_,_) := ?x in _] |- _] => destruct x as [?l ?r] eqn:?Heq
     | [ H : (_, _) = (_, _) |- _] => inversion H; subst; clear H
@@ -681,11 +681,11 @@ Proof.
   induction c; intros cst cst' e r Htr; simpl in Htr; compile.
 
   - (* Case "CSkip".*)
-    reflexivity. 
+    reflexivity.
 
-  - (* Case "CAss". *) 
+  - (* Case "CAss". *)
   eapply fresh_add_incr_strong; eauto.
-  eapply ectmon_incr_strong; eauto. 
+  eapply ectmon_incr_strong; eauto.
 
   - (* Case "CSeq". *)
   eapply transitivity.
@@ -694,7 +694,7 @@ Proof.
   -  (* Case "CIf". *)
   eapply transitivity. eapply IHc1; eauto.
   eapply transitivity. eapply IHc2; eauto.
-  eapply fresh_add_incr_strong; eauto. 
+  eapply fresh_add_incr_strong; eauto.
   eapply ectmon_incr_strong; eauto.
 
   - (* Case "CWhile". *)
@@ -702,7 +702,7 @@ Proof.
   eauto. eapply transitivity. eapply IHc; eauto.
   eapply ectmon_incr_strong; eauto. eauto.
 Qed.
-  
+
 
 Lemma cstate_incr_weaken : forall cst cst',
   cstate_incr_strong cst cst' ->
@@ -729,7 +729,7 @@ Lemma match_init : forall c le lr csti cst x g' e,
   match_config c (e, g', le, lr).
 Proof.
   induction c; intros le lr csti cst x g' e Hcomp Hincr; simpl in Hcomp; compile.
-  
+
   - (* Case "CSkip". *)
   apply MC_Skip.
 
@@ -742,10 +742,10 @@ Proof.
     inversion Heq1; subst; clear Heq1.
 
     eapply MC_Ass, cfg_insns_at.
-    inversion Hincr. subst. 
+    inversion Hincr. subst.
     apply H5. left; auto.
-    apply comp_store_not_nil. rewrite ListCFG.update_eq; auto. 
-    f_equal. rewrite surjective_pairing in Hc' at 1. 
+    apply comp_store_not_nil. rewrite ListCFG.update_eq; auto.
+    f_equal. rewrite surjective_pairing in Hc' at 1.
     inversion Hc'. reflexivity.
 
   - (* Case "CSeq". *)
@@ -757,7 +757,7 @@ Proof.
 
     + eapply IHc1; eauto.
       eapply transitivity. eapply comp_com_incr; eauto.
-      eapply transitivity; eauto. eapply cstate_incr_weaken. 
+      eapply transitivity; eauto. eapply cstate_incr_weaken.
       eapply fresh_add_incr_strong; eauto.
       eapply ectmon_incr_strong; eauto.
 
@@ -774,16 +774,16 @@ Proof.
       inversion Hincr. subst.
       apply H5. left; auto.
       apply comp_cond_not_nil.
-      rewrite ListCFG.update_eq; auto. 
+      rewrite ListCFG.update_eq; auto.
       f_equal.
-      rewrite surjective_pairing in Heq1 at 1. 
+      rewrite surjective_pairing in Heq1 at 1.
       inversion Heq1. reflexivity.
-      
+
   - (* Case "CWhile". *)
     eapply MC_While with (cs:=ids2).
 
     + simpl in Heq. inversion Heq; subst. clear Heq.
-    
+
       eapply IHc. eauto.
       apply comp_com_incr_strong in Heq0.
       apply ectmon_incr_strong in Heq1.
@@ -793,7 +793,7 @@ Proof.
       apply add_insns_incr in Heq2; eauto.
 
       inversion Heq1. subst. rewrite <- H6.
-      inversion Heq0. subst. rewrite <- H8. 
+      inversion Heq0. subst. rewrite <- H8.
       rewrite ListCFG.update_eq; auto.
       left. auto.
       inversion Heq0. subst. apply H2. left. auto.
@@ -801,18 +801,18 @@ Proof.
     + inversion Heq.  subst.
 
       apply cfg_insns_at.
-      inversion Hincr. subst. 
+      inversion Hincr. subst.
       apply H5.
 
       apply comp_com_incr_strong in Heq0.
-      apply ectmon_incr_strong in Heq1.      
+      apply ectmon_incr_strong in Heq1.
       inversion Heq0. subst.
       inversion Heq2. subst.
       inversion Heq1. subst.
       apply H3. apply H2. left. reflexivity.
-      
+
       apply comp_cond_not_nil.
-      
+
       inversion Heq2. subst. rewrite ListCFG.update_eq; auto.
       f_equal. rewrite surjective_pairing in Heq1 at 1.
       inversion Heq1. subst. unfold strun.
@@ -839,7 +839,7 @@ Hypothesis simulation:
   forall S1 S1' S2,
   step1 S1 S1' -> match_states S1 S2 ->
   exists S2',
-    (plus step2 S2 S2' \/ 
+    (plus step2 S2 S2' \/
      star step2 S2 S2' /\ measure S1' < measure S1) /\
     match_states S1' S2'.
 
@@ -856,8 +856,8 @@ Proof.
   - (* Case "one or more transitions". *)
   destruct (simulation _ _ _ H H1) as [S2' [P Q]].
   destruct (IHstar _ Q) as [S2'' [U V]].
-  exists S2''; split. 
-  eapply star_trans; eauto. destruct P. 
+  exists S2''; split.
+  eapply star_trans; eauto. destruct P.
   apply plus_star; auto. destruct H2; auto.
   auto.
 Qed.
@@ -872,9 +872,9 @@ Lemma simulation_infseq_productive:
    /\ infseq step1 S1'
    /\ match_states S1' S2'.
 Proof.
-  induction N; intros. 
+  induction N; intros.
   - (* Case "N = 0". *)
-  omega. 
+  omega.
   - (* Case "N > 0". *)
   inversion H0; clear H0; subst.
   destruct (simulation _ _ _ H2 H1) as [S2' [P Q]].
@@ -895,14 +895,14 @@ Lemma simulation_infseq:
   match_states S1 S2 ->
   infseq step2 S2.
 Proof.
-  intros. 
+  intros.
   apply infseq_coinduction_principle_2 with
     (X := fun S2 => exists S1, infseq step1 S1 /\ match_states S1 S2).
-  intros. destruct H1 as [S [A B]]. 
-  destruct (simulation_infseq_productive (measure S + 1) S a) 
+  intros. destruct H1 as [S [A B]].
+  destruct (simulation_infseq_productive (measure S + 1) S a)
   as [S1' [S2' [P [Q R]]]].
   omega. auto. auto.
-  exists S2'; split. auto. exists S1'; auto. 
+  exists S2'; split. auto. exists S1'; auto.
   exists S1; auto.
 Qed.
 
@@ -914,7 +914,7 @@ Definition vminus_terminates (g:ListCFG.t) (m m':mem) : Prop :=
     insns_at_pc g st'.(st_pc) [(x, cmd_tmn tmn_ret)] /\
     st'.(st_mem) = m' /\
     star (step g) (init_state g m) st'.
-  
+
 Definition vminus_diverges (g:ListCFG.t) (m:mem) : Prop :=
   infseq (step g) (init_state g m).
 
@@ -929,7 +929,7 @@ Lemma match_config_ret : forall g le lr c,
   exists x, insns_at_pc g (block_entry lr) [(x, cmd_tmn tmn_ret)].
 Proof.
   intros. unfold compile, comp_prog in H. simpl in H. compile.
-  
+
   eexists. eapply cfg_insns_at. apply comp_com_incr_strong in Heq1.
   inversion Heq1; subst. rewrite <- H6. rewrite ListCFG.update_eq; auto.
   left. reflexivity.
@@ -942,7 +942,7 @@ Proof.
   intros. unfold compile, comp_prog in H. simpl in H. compile.
   econstructor; simpl; eauto.
 
-  eapply match_init. eauto. eapply cstate_incr_weaken. 
+  eapply match_init. eauto. eapply cstate_incr_weaken.
   eapply cstate_incr_strong_refl.
 Qed.
 
@@ -953,15 +953,15 @@ Theorem compile_program_correct_terminating:
   vminus_terminates g m m'.
 Proof.
   intros. unfold imp_terminates in H.
-  assert (exists machconf2, 
+  assert (exists machconf2,
            star (step g) (init_state g m) machconf2
            /\ match_states g lr (SKIP, m') machconf2).
-  eapply simulation_star; eauto. eapply transl_sim_step_final. 
+  eapply simulation_star; eauto. eapply transl_sim_step_final.
   eapply match_config_initial; eauto.
-  destruct H1 as [machconf2 [STAR MS]]. 
+  destruct H1 as [machconf2 [STAR MS]].
   inversion MS; subst.
   eelim match_config_ret. intros.
-  red. exists x, machconf2. split. rewrite H4. eauto. eauto. 
+  red. exists x, machconf2. split. rewrite H4. eauto. eauto.
   inversion H3; subst. eauto.
 Qed.
 
@@ -971,7 +971,7 @@ Theorem compile_program_correct_diverging:
   imp_diverges c m ->
   vminus_diverges g m.
 Proof.
-  intros; red; intros. 
+  intros; red; intros.
   eapply simulation_infseq with (match_states := match_states g lr); eauto.
   eapply transl_sim_step_final. eapply match_config_initial; eauto.
 Qed.

--- a/vminus/CompilerTest.v
+++ b/vminus/CompilerTest.v
@@ -23,34 +23,34 @@ Require Import Vminus.OpSemGen.
 Require Import Vminus.Stmon.
 
 (** ** QuickChick and Vellvm **************************************************)
-(** One may expect a compiler for a language as simple as IMP to be relatively 
+(** One may expect a compiler for a language as simple as IMP to be relatively
     straightforward, and a proof of its correctness to be correspondingly
-    so. However, LLVM is a full-featured IR, and a faithful formalization 
-    is necessarily complex and large. When the compiler is under development, 
-    even stating the correctness of the compiler can be difficult, much 
+    so. However, LLVM is a full-featured IR, and a faithful formalization
+    is necessarily complex and large. When the compiler is under development,
+    even stating the correctness of the compiler can be difficult, much
     less prove it.
 
-    But if we have interpreters for both the source and target, testing the 
-    compiler is a much simpler affair. Moreover, the simplicity of the source 
+    But if we have interpreters for both the source and target, testing the
+    compiler is a much simpler affair. Moreover, the simplicity of the source
     language, i.e. Imp. means that it is really easy to test! *)
 
 (** This lecture shows how QuickChick can be used to test the compiler. For
     simplicity, the target language is the simplified SSA language Vminus, and
-    we use a variant of Imp whose names are just memory addresses which can be 
+    we use a variant of Imp whose names are just memory addresses which can be
     interpreted in the memory of Vminus states. Imp states and Vminus memory
-    are hence essentially the same, and this makes it easy to state correct 
-    compilation: after running the source program and its compilation, 
-    every Imp variable/address is mapped to the same nat by both the Imp state 
-    and Vminus memory. 
+    are hence essentially the same, and this makes it easy to state correct
+    compilation: after running the source program and its compilation,
+    every Imp variable/address is mapped to the same nat by both the Imp state
+    and Vminus memory.
 
-    A Vminus state consists of a memory (mapping addresses to nat), a program 
-    counter, an environment mapping locals to nat, a "previous" program 
+    A Vminus state consists of a memory (mapping addresses to nat), a program
+    counter, an environment mapping locals to nat, a "previous" program
     counter, and a "previous" environment. The latter two are needed for
     executing phi nodes. A configuration consists of a Vminus state and a CFG,
     which "holds" Vminus instructions organized in basic blocks.
 *)
 
-(** Here's a look at what we mean. 
+(** Here's a look at what we mean.
 
 Theorem compile_program_correct_terminating:
   forall c m m' g le lr,
@@ -58,21 +58,21 @@ Theorem compile_program_correct_terminating:
   imp_terminates c m m' ->
   vminus_terminates g m m'.
 
-  This is one of the top-level correctness theorems for the compiler: for any 
-  initial memory m, if the source program c terminates with memory (Imp state) 
-  m', running the compilation result g (a control flow graph holding the 
+  This is one of the top-level correctness theorems for the compiler: for any
+  initial memory m, if the source program c terminates with memory (Imp state)
+  m', running the compilation result g (a control flow graph holding the
   instructions) on the same initial memory m also results in termination, and
-  with its final (Vminus) memory also being m. This is where the coincidence of 
+  with its final (Vminus) memory also being m. This is where the coincidence of
   Imp states and Vminus memory comes into play.
-  
+
   Terminating Imp programs are those that are evaluated to just SKIP, as the
-  following definition shows. 
+  following definition shows.
 
   Definition imp_terminates (c: com) (m m':mem) : Prop :=
     star Imp.step (c, m) (SKIP, m').
 
-  For Vminus programs on the other hand, running them on an initial memory m 
-  leads to termination with memory m' if execution reaches some uid x 
+  For Vminus programs on the other hand, running them on an initial memory m
+  leads to termination with memory m' if execution reaches some uid x
   associated with a return terminator.
 
   Definition vminus_terminates (g:ListCFG.t) (m m':mem) : Prop :=
@@ -81,30 +81,30 @@ Theorem compile_program_correct_terminating:
       st'.(st_mem) = m' /\
       star (step g) (init_state g m) st'.
 
-  The variables x and st' here are determined by "running"/evaluation, as 
-  indicated by "star (step g) (init_state g m) st'". So checking for their 
-  existence is really verifying that an evaluation function reaches st' 
-  satisfying the constraints. 
+  The variables x and st' here are determined by "running"/evaluation, as
+  indicated by "star (step g) (init_state g m) st'". So checking for their
+  existence is really verifying that an evaluation function reaches st'
+  satisfying the constraints.
  *)
 
-(** Let us try to write a Checker for the theorem. Looking at the universals, 
-    it would appear that we need generators for Imp commands (c), Imp 
+(** Let us try to write a Checker for the theorem. Looking at the universals,
+    it would appear that we need generators for Imp commands (c), Imp
     states/memories (m, m'), control flow graphs (g) and labels (le, lr).
-    However, note that g, le, and lr are computed by "compile c", so we 
-    don't actually need generators for them. Moreover, we do not want just any 
+    However, note that g, le, and lr are computed by "compile c", so we
+    don't actually need generators for them. Moreover, we do not want just any
     c and m', but only terminating Imp programs, and m' is obtained by running
     an Imp evaluator on m. Hence for generation, we only need:
-    - A generator for mem. 
-    - A generator for Imp programs that are guaranteed to terminate. 
+    - A generator for mem.
+    - A generator for Imp programs that are guaranteed to terminate.
     And for checking, we would need:
     - An evaluator for Imp that reaches termination, i.e. SKIP.
-    - An evaluator for Vminus that reaches termination, i.e. a return 
-      terminator. 
-    - We also need to check that the final state st' that the Vminus evaluator 
+    - An evaluator for Vminus that reaches termination, i.e. a return
+      terminator.
+    - We also need to check that the final state st' that the Vminus evaluator
       reaches has the desired memory.
 *)
 
-(** Let us first define an evaluator for Vminus. The evaluator stops when 
+(** Let us first define an evaluator for Vminus. The evaluator stops when
     a return terminator is reached. *)
 
 Fixpoint vminus_eval (g: ListCFG.t) (s : state) (fuel: nat) : err state :=
@@ -124,12 +124,12 @@ Fixpoint vminus_eval (g: ListCFG.t) (s : state) (fuel: nat) : err state :=
     end
   end.
 
-(** It is likely that QuickChick will generate large enough Imp programs such 
+(** It is likely that QuickChick will generate large enough Imp programs such
     that vminus_eval can run out of fuel. (Think of large aexp expressions.)
 
-    Exercise: Write an instance of GenSized for aexp and bexp such that 
-    any size above a certain number, say 5, is rounded down to that. The 
-    GenSized instance for bexp should make use of that for aexp. 
+    Exercise: Write an instance of GenSized for aexp and bexp such that
+    any size above a certain number, say 5, is rounded down to that. The
+    GenSized instance for bexp should make use of that for aexp.
  *)
 
 Derive Arbitrary for aexp.
@@ -163,21 +163,21 @@ Instance gen_small_bexp: GenSized bexp :=
        gen_bexp_func (round_down_to 5 n)
   |}.
 
-(** For com, recall that the lemma applies only to terminating ones. Hence, 
-    write two sized generators for com: 
-    - one that generates only assignment statements and SKIPs, such that the 
+(** For com, recall that the lemma applies only to terminating ones. Hence,
+    write two sized generators for com:
+    - one that generates only assignment statements and SKIPs, such that the
       latter are generated with low probability.
     - one that generates IF-THEN-ELSE, assignments and SKIPs, but no loops.
  *)
 
 Fixpoint gen_seq_com (n : nat) : G com :=
   (* FILL IN HERE *)
-  match n with 
+  match n with
   | 0 => freq [(4, liftGen2 CAss arbitrary arbitrary); (1, returnGen SKIP)]
   | S n' =>
     let gen := gen_seq_com n' in
     liftGen2 CSeq gen gen
-  end. 
+  end.
 
 Fixpoint gen_if_com (n: nat) : G com :=
   (* FILL IN HERE *)
@@ -189,22 +189,22 @@ Fixpoint gen_if_com (n: nat) : G com :=
     oneOf [liftGen3 CIf arbitrary gen gen; liftGen2 CSeq gen gen]
   end.
 
-(** For your convenience, the Shows and Shrinks for aexp, bexp and com have 
+(** For your convenience, the Shows and Shrinks for aexp, bexp and com have
     been defined. *)
 
-(** The last thing we need a generator for is mem. One could generate this by 
-    first generating a subset of its domain, i.e. Atom.t, and then generating 
-    the image for this subset; the rest would be kept as some initial value. 
+(** The last thing we need a generator for is mem. One could generate this by
+    first generating a subset of its domain, i.e. Atom.t, and then generating
+    the image for this subset; the rest would be kept as some initial value.
 *)
 
-(** Write a function that outputs a generator for mem, given a list of 
-    atoms. 
+(** Write a function that outputs a generator for mem, given a list of
+    atoms.
 *)
 
 Definition gen_mem_from_atom_list
            (atom_list : list Atom.t) : G mem :=
   (* FILL IN HERE *)
-  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list => 
+  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list =>
   returnGen (fun (a : Atom.t) =>
                match (index_of_atom_in_list a atom_list) with
                | None => 0
@@ -214,13 +214,13 @@ Definition gen_mem_from_atom_list
 
 (** Now write a generator for Atom.t. You may find the function get_fresh_atoms
     useful: it takes in (n: nat) and a list of atoms, and outputs a list of n
-    atoms that are distinct from the input. 
+    atoms that are distinct from the input.
 *)
 
 Check get_fresh_atoms 6 [].
 
 Instance gen_domain : Gen Atom.t :=
-  (* FILL IN HERE *)  
+  (* FILL IN HERE *)
   {| arbitrary :=
        let atom_store := get_fresh_atoms 100 [] in
        oneof (returnGen (Atom.fresh [])) (List.map returnGen atom_store)
@@ -230,12 +230,12 @@ Instance gen_domain : Gen Atom.t :=
 
 Check show_memory.
 
-(** With generation out of the way, we can now return to checking. 
+(** With generation out of the way, we can now return to checking.
     The Vminus evaluator defined earlier solves a part of the puzzle, namely
-    the question of how to check the existence of st' and x. However, we also 
-    need to check that st' has the desired memory. Because memories here are 
-    total maps, we can only check for equality of memories for a specified 
-    domain. 
+    the question of how to check the existence of st' and x. However, we also
+    need to check that st' has the desired memory. Because memories here are
+    total maps, we can only check for equality of memories for a specified
+    domain.
 *)
 
 Fixpoint memory_on_domain_checker
@@ -271,11 +271,11 @@ Definition vminus_termination_checker
 
 Definition compile_program_correct_terminating_checker: Checker :=
   forAll (gen_seq_com 5) (fun (c : Imp.com) =>
-  forAll arbitrary (fun (dom : list Atom.t) => 
+  forAll arbitrary (fun (dom : list Atom.t) =>
   forAllShrinkShow (gen_mem_from_atom_list dom)
                    (fun x => []) (* dummy shrinker *)
                    (fun m => show_memory m dom) (* show just for the domain *)
-                   (fun m => 
+                   (fun m =>
   let '(g, le, lr) := compile c in
     match imp_eval c m 100 with
     | Some s' =>
@@ -284,13 +284,13 @@ Definition compile_program_correct_terminating_checker: Checker :=
                       false
     end))).
 
-(** Note the use of forAllShrinkShow here, which lets us choose the specific 
-    Show we want to use; it is needed here because we don't have a Show 
+(** Note the use of forAllShrinkShow here, which lets us choose the specific
+    Show we want to use; it is needed here because we don't have a Show
     instance for total maps like mem. *)
 
 (* ! QuickChick compile_program_correct_terminating_checker. *)
 
-(** For the next part, let us go into the sort of lemmas that would be needed 
+(** For the next part, let us go into the sort of lemmas that would be needed
     to prove the top-level correctness theorems like the one above. Here's one.
 
 Lemma comp_aexp_correct : forall (a:aexp),
@@ -299,7 +299,7 @@ Lemma comp_aexp_correct : forall (a:aexp),
 Definition comp_correct (comp : ectmon (val * list insn))
            (eval : mem -> nat) : Prop :=
   forall (cs cs': list uid) (g: ListCFG.t) (st: V.Opsem.state)
-    (is k: list insn) (v: val), 
+    (is k: list insn) (v: val),
     (cs', (v, is)) = comp cs ->
     insns_at_pc g (st_pc st) (is ++ k) ->
     exists st',
@@ -313,52 +313,52 @@ Definition comp_correct (comp : ectmon (val * list insn))
 *)
 
 (** That is, compiling Imp aexp is correct if:
-    - for any compilation run on an initial list of uids, 
+    - for any compilation run on an initial list of uids,
     - wherever we place the compilation result "is" in the CFG, as long
       as the pc is pointed to it, (insns_at_pc g (st_pc) (is ++ k)),
     - we can run to the end of compilation (insns_at_pc g (st_pc st') k),
-    - and in this state st', the memory is the same as above; but evaluating 
+    - and in this state st', the memory is the same as above; but evaluating
       the result of the expression in this state (eval_val (st_loc st') v)
       is exactly the same as evaluating it according to the Imp state
-      (eval (st_mem st)). 
-    - This last fact may not be obvious from the body of comp_correct. But note 
-      comp_aexp_correct; the evaluation function passed to it is Imp's aeval, 
-      and this is where the coincidence of Imp states and Vminus memory comes 
+      (eval (st_mem st)).
+    - This last fact may not be obvious from the body of comp_correct. But note
+      comp_aexp_correct; the evaluation function passed to it is Imp's aeval,
+      and this is where the coincidence of Imp states and Vminus memory comes
       into play.
     There is a bunch of other things that we need here, so as to prove correct
     compilation for com. But the above description is the crux.
 *)
 
-(** Looking at comp_correct, it is clear that we need to generate more than 
-    just the things we had before. In particular, it would seem that we need 
+(** Looking at comp_correct, it is clear that we need to generate more than
+    just the things we had before. In particular, it would seem that we need
     generators for the following:
     - uid
     - CFG
     - Vminus states
     - Vminus instructions
     - values
-    But note again that the only value v (with cs', is) is computed by comp 
-    rather than generated, so we don't actually need a generator for value. 
-    Moreover, the CFG g should not be generated randomly the same way we do 
-    others, because it has to satisfy insns_at_pc; it is unlikely for just 
+    But note again that the only value v (with cs', is) is computed by comp
+    rather than generated, so we don't actually need a generator for value.
+    Moreover, the CFG g should not be generated randomly the same way we do
+    others, because it has to satisfy insns_at_pc; it is unlikely for just
     "any" CFG to satisfy this precondition of the lemma. *)
 
 (**
-    Exercise: Generators and Shows for uid and Vminus instructions, using 
-    automation as much as possible. (It is however useful to have custom Shows 
+    Exercise: Generators and Shows for uid and Vminus instructions, using
+    automation as much as possible. (It is however useful to have custom Shows
     that are more descriptive.) *)
 
 (* FILL IN HERE *)
 
-(** For Vminus states, we already have a generator for mem. We have defined a 
+(** For Vminus states, we already have a generator for mem. We have defined a
     generator and show for loc for you. *)
 
 Check gen_loc_from_atom_list.
 Check show_locals.
 
-(** Hence, write a generator and a show function for Vminus states, 
-    given domains for mem and loc. For simplicity, we can use the same 
-    domain for ploc. 
+(** Hence, write a generator and a show function for Vminus states,
+    given domains for mem and loc. For simplicity, we can use the same
+    domain for ploc.
  *)
 
 Definition gen_vminus_state
@@ -390,22 +390,22 @@ Definition show_vminus_state
                "ppc: " ++ show (st_ppc st) ++ ", " ++
                "prev_loc: " ++ show_locals (st_ploc st) loc_dom)%string.
 
-(** With these out of the way, we can now address the remaining gaps. In its 
-    current form, comp_correct is inefficient and challenging for testing. 
-    Firstly, some of the quantities are computed by a function, so it is 
-    unnecessary to generate them in the first place, although seemingly 
-    suggested by "forall". Secondly, the CFG g is not just any CFG, but one 
-    that satisfies insns_at_pc for the compilation result - random generation 
+(** With these out of the way, we can now address the remaining gaps. In its
+    current form, comp_correct is inefficient and challenging for testing.
+    Firstly, some of the quantities are computed by a function, so it is
+    unnecessary to generate them in the first place, although seemingly
+    suggested by "forall". Secondly, the CFG g is not just any CFG, but one
+    that satisfies insns_at_pc for the compilation result - random generation
     in the usual way is very, very unlikely to meet this condition, so most
-    checks would end up being vacuously true. Thirdly, a Checker for the 
+    checks would end up being vacuously true. Thirdly, a Checker for the
     the existence of st' really needs to compute it, and this is not part of
-    the lemma itself. 
+    the lemma itself.
 
-    Hence the first order of affairs is to massage the lemma into a 
+    Hence the first order of affairs is to massage the lemma into a
     Checker-friendly version.
  *)
 
-(** Firstly, let us drop the unnecessary variables, and note the generation 
+(** Firstly, let us drop the unnecessary variables, and note the generation
     of state.
 
     Definition comp_correct (comp : ectmon (val * list insn))
@@ -429,19 +429,19 @@ Definition show_vminus_state
     Checker.
  *)
 
-(** Secondly, we need to write a custom generator that generates CFGs 
-    satisfying insns_at_pc. An easier option is to just construct a CFG that 
-    loads the instructions at a given pc. 
+(** Secondly, we need to write a custom generator that generates CFGs
+    satisfying insns_at_pc. An easier option is to just construct a CFG that
+    loads the instructions at a given pc.
 
-    Let us call this wrap_code_in_cfg' pc is k, in correspondence with 
+    Let us call this wrap_code_in_cfg' pc is k, in correspondence with
     insns_at_pc g (st_pc st) (is ++ k).
 
-    However, because pc may have a positive offset into the block, we should 
+    However, because pc may have a positive offset into the block, we should
     also fill the initial instructions with some dummy instructions (that won't
-    be executed). So make wrap_code_in_cfg' do this. 
+    be executed). So make wrap_code_in_cfg' do this.
 *)
 
-(* Returns a CFG with a single block containing instrs ++ instrs_after, 
+(* Returns a CFG with a single block containing instrs ++ instrs_after,
     and the pc in that block that begins at instrs_after *)
 Definition wrap_code_in_cfg' (p: pc) (instrs instrs_after: list insn)
   : ListCFG.t :=
@@ -471,21 +471,21 @@ Definition wrap_code_in_cfg' (p: pc) (instrs instrs_after: list insn)
         ids_preserved cs st st' /\
         good_return cs' v /\
         ctx_incr cs cs' /\
-        eval_val (st_loc st') v = Some (eval (st_mem st)). 
+        eval_val (st_loc st') v = Some (eval (st_mem st)).
 *)
 
 (** Thirdly, if we have grasped the meaning of the lemma, we know that st'
-    is given by executing the compilation result; this is the point of 
-    "loading" the compilation result at the current pc in g, and is of course 
-    also stated by "star (Opsem.step g) st st'". So we need an executable 
-    evaluator for Vminus. The state st' is obtained by running this evaluator 
-    until we reach (the start of) k. 
-    
+    is given by executing the compilation result; this is the point of
+    "loading" the compilation result at the current pc in g, and is of course
+    also stated by "star (Opsem.step g) st st'". So we need an executable
+    evaluator for Vminus. The state st' is obtained by running this evaluator
+    until we reach (the start of) k.
+
     The simplest way of doing so is to stop at the program counter that begins
-    k, and this is actually determined by the CFG that loaded (is ++ k). 
+    k, and this is actually determined by the CFG that loaded (is ++ k).
 *)
 
-(** Exercise: Change wrap_code_in_cfg to return (g, pc), where the latter is 
+(** Exercise: Change wrap_code_in_cfg to return (g, pc), where the latter is
     the pc that begins k. *)
 
 Definition wrap_code_in_cfg (p: pc) (instrs instrs_after: list insn)
@@ -516,7 +516,7 @@ Check V.Opsem.eval_step.
 
       match V.Opsem.eval_until_pc g st cutpoint 1000 with
       | inl err => false (* either out of fuel or no st' *)
-      | inr st' => 
+      | inr st' =>
         st_mem st' = st_mem st /\
         insns_at_pc g (st_pc st') k /\
         star (Opsem.step g) st st' /\
@@ -528,10 +528,10 @@ Check V.Opsem.eval_step.
  *)
 
 (** And with this, the major obstacles are out of the way, and we only have
-    to write a Checker for the big conjunction. Because the conjunction is 
+    to write a Checker for the big conjunction. Because the conjunction is
     huge, it is easier to write a Checker for each conjunct. That is, we would
     like to have:
-    - A Checker that checks that two memories are the same. This has already 
+    - A Checker that checks that two memories are the same. This has already
       been done.
     - A Checker that checks for insns_at_pc g.
     - A Checker for ids_preserved.
@@ -539,8 +539,8 @@ Check V.Opsem.eval_step.
     - A Checker for ctxt_incr.
     - A Checker that checks for equality between the two ways of evaluation.
     Note that "star (Opsem.step g) st st'" doesn't need checking, because it is
-    implicit in eval_until_pc. With respect to correctness of aexp compilation 
-    itself, the last is most relevant. 
+    implicit in eval_until_pc. With respect to correctness of aexp compilation
+    itself, the last is most relevant.
 
     To give a headstart, most of these are defined below.
 *)
@@ -595,7 +595,7 @@ Definition ids_preserved_checker (cs : list uid) (st st': state)
 Definition good_return_checker (cs: list uid) (v: val) : Checker :=
   match v with
   | val_uid uid =>
-    whenFail "good_return: cannot find value" 
+    whenFail "good_return: cannot find value"
              (List.existsb
                 (fun uid' => if eq_dec_uid uid uid' then true else false) cs)
   | val_nat n => checker true
@@ -626,11 +626,11 @@ Definition expression_step_checker
              ctx_incr_checker cs cs';
              eval_equal_checker eval final_state v].
 
-(** Finally, a Checker for comp_correct and comp_aexp could look like the 
-    following. It is convenient to split the Checker into a part that does 
-    only the generation, and a part that does the checking, because a type 
+(** Finally, a Checker for comp_correct and comp_aexp could look like the
+    following. It is convenient to split the Checker into a part that does
+    only the generation, and a part that does the checking, because a type
     error can cause the typechecker to get stuck trying to resolve the issue
-    by looking for typeclass instances that don't exist.    
+    by looking for typeclass instances that don't exist.
 *)
 
 Definition comp_correct_checker_inner
@@ -641,7 +641,7 @@ Definition comp_correct_checker_inner
   let '(g, endpoint) := wrap_code_in_cfg (V.Opsem.st_pc st) instrs k in
   match V.Opsem.eval_until_pc g st endpoint 1000 with
   | inl err => whenFail ("comp_correct_checker: " ++ err) false
-  | inr st' => 
+  | inr st' =>
     expression_step_checker eval g st st' k endpoint cs cs' v
   end.
 
@@ -655,7 +655,7 @@ Definition comp_correct_checker
   forAllShrinkShow (gen_vminus_state mem_dom loc_dom)
                    (fun x => [])
                    (show_vminus_state mem_dom loc_dom)
-                   (fun (start_state: state) => 
+                   (fun (start_state: state) =>
     comp_correct_checker_inner
       comp eval
       cs start_state extra_insn))))).
@@ -668,13 +668,13 @@ Definition comp_aexp_correct_checker :=
 
 (* ! QuickChick comp_aexp_correct_checker. *)
 
-(** Since the compiler has already been proven correct, all tests should 
-    succeed. However, they could be succeeding for rather vacuous reasons, and 
-    it would be assuring to know that the Checker indeed fails when the 
-    compiler is wrong. 
+(** Since the compiler has already been proven correct, all tests should
+    succeed. However, they could be succeeding for rather vacuous reasons, and
+    it would be assuring to know that the Checker indeed fails when the
+    compiler is wrong.
 
-    Exercise: Add mutants to comp_aexp, and verify that they are causing 
-    comp_aexp_correct_checker to fail. 
+    Exercise: Add mutants to comp_aexp, and verify that they are causing
+    comp_aexp_correct_checker to fail.
  *)
 
 (** Exercise: Write a Checker for the following lemma, and run it.
@@ -690,30 +690,30 @@ Definition comp_bop_correct_checker: Checker :=
   (* FILL IN HERE *)
   forAll arbitrary (fun (a1: aexp) =>
   forAll arbitrary (fun (a2: aexp) =>
-  forAll arbitrary (fun (binop: bop) => 
-    collect binop (comp_correct_checker 
+  forAll arbitrary (fun (binop: bop) =>
+    collect binop (comp_correct_checker
       (comp_bop binop (comp_aexp a1) (comp_aexp a2))
       (fun m => V.Opsem.bop_denote binop (aeval a1 m) (aeval a2 m)))))).
 
 (* ! QuickChick comp_bop_correct_checker. *)
 
 Definition comp_bexp_correct_checker : Checker :=
-  forAll arbitrary (fun b: bexp => 
+  forAll arbitrary (fun b: bexp =>
     comp_correct_checker (comp_bexp b) (fun m => if (beval b m) then 1 else 0)).
 
 (* ! QuickChick comp_bexp_correct_checker. *)
 
-(** Exercise: Write a Checker for the following lemma, and make sure that all 
-    tests pass. 
+(** Exercise: Write a Checker for the following lemma, and make sure that all
+    tests pass.
 
 Lemma comp_bexp_correct : forall (b:bexp),
   comp_correct (comp_bexp b) (fun m => b2n (beval b m)).
 *)
 
-(** Exercise: Write a Checker for the following lemma, and make sure that all 
+(** Exercise: Write a Checker for the following lemma, and make sure that all
     tests pass.
 
-Lemma comp_store_correct : 
+Lemma comp_store_correct :
   forall g a v le lr cs st,
   insns_at_pc g (block_entry le) (steval (comp_store a v lr) cs) ->
   st_pc st = (block_entry le) ->
@@ -738,7 +738,7 @@ Definition comp_store_correct_checker_inner
   | inr st' =>
     if (eq_dec_pc (V.Opsem.st_pc st') (block_entry lr)) then
       let new_dom := (v :: mem_dom) in
-      whenFail 
+      whenFail
         "comp_store_correct: memories mismatch"
         (memory_on_domain_checker new_dom
           (V.Opsem.st_mem st')
@@ -755,14 +755,14 @@ Definition comp_store_correct_checker: Checker :=
   forAll arbitrary (fun (cs: list uid) =>
   forAll arbitrary (fun (mem_dom: list Atom.t) =>
   forAll arbitrary (fun (loc_dom: list Atom.t) =>
-  forAllShrinkShow (gen_vminus_state mem_dom loc_dom)                      
+  forAllShrinkShow (gen_vminus_state mem_dom loc_dom)
                    (fun x => [])
                    (show_vminus_state mem_dom loc_dom)
-                   (fun (vst: state) => 
+                   (fun (vst: state) =>
     comp_store_correct_checker_inner a v lr le cs mem_dom loc_dom vst)))))))).
 
 
-(** Exercise: Write a Checker for the following lemma, and make sure that all 
+(** Exercise: Write a Checker for the following lemma, and make sure that all
     tests pass.
 
 Lemma comp_cond_correct :
@@ -785,17 +785,17 @@ Definition comp_cond_correct_checker_inner
   let '(g, end_pc) :=
       wrap_code_in_cfg (block_entry le)
                        (steval (comp_cond b l1 l2) cs) [] in
-  let l := (if beval b (V.Opsem.st_mem st) then l1 else l2) in  
+  let l := (if beval b (V.Opsem.st_mem st) then l1 else l2) in
   match (V.Opsem.eval_until_pc g st (block_entry l) 1000) with
   | inl err =>
-    whenFail 
+    whenFail
       ("::: cfg is: " ++ show g ++
        "::: comp_cond_correct: " ++ err ++
        "::: looking for pc: " ++ show end_pc
       )
       false
   | inr st' =>
-    if (eq_dec_pc (V.Opsem.st_pc st') (block_entry l)) then 
+    if (eq_dec_pc (V.Opsem.st_pc st') (block_entry l)) then
       whenFail "comp_store_correct: memories mismatch"
                (memory_on_domain_checker mem_dom
                                          (st_mem st)
@@ -811,10 +811,10 @@ Definition comp_cond_correct_checker : Checker :=
   forAll arbitrary (fun (cs: list uid) =>
   forAll arbitrary (fun (mem_dom: list Atom.t) =>
   forAll arbitrary (fun (loc_dom: list Atom.t) =>
-  forAllShrinkShow (gen_vminus_state mem_dom loc_dom)                      
+  forAllShrinkShow (gen_vminus_state mem_dom loc_dom)
                    (fun x => [])
                    (show_vminus_state mem_dom loc_dom)
-                   (fun (vst: state) => 
+                   (fun (vst: state) =>
     comp_cond_correct_checker_inner b cs le l1 l2 mem_dom loc_dom vst)))))))).
 
 (* ! QuickChick comp_cond_correct_checker. *)

--- a/vminus/CompilerTestAnswers.v
+++ b/vminus/CompilerTestAnswers.v
@@ -25,12 +25,12 @@ Import V.Opsem.
 
 (**! Section test_compile_bexp extends compiler *)
 
-(* Fatal error with stack overflow 
+(* Fatal error with stack overflow
 Definition comp_bop_correct_checker: Checker :=
   forAll arbitrary (fun (a1: aexp) =>
   forAll arbitrary (fun (a2: aexp) =>
-  forAll arbitrary (fun (binop: bop) => 
-    collect (binop, a1, a2) (comp_correct_checker 
+  forAll arbitrary (fun (binop: bop) =>
+    collect (binop, a1, a2) (comp_correct_checker
       (comp_bop binop (comp_aexp a1) (comp_aexp a2))
       (fun m => V.Opsem.bop_denote binop (aeval a1 m) (aeval a2 m)))))).
  *)
@@ -38,22 +38,22 @@ Definition comp_bop_correct_checker: Checker :=
 Definition comp_bop_correct_checker: Checker :=
   forAll arbitrary (fun (a1: aexp) =>
   forAll arbitrary (fun (a2: aexp) =>
-  forAll arbitrary (fun (binop: bop) => 
-    collect binop (comp_correct_checker 
+  forAll arbitrary (fun (binop: bop) =>
+    collect binop (comp_correct_checker
       (comp_bop binop (comp_aexp a1) (comp_aexp a2))
       (fun m => V.Opsem.bop_denote binop (aeval a1 m) (aeval a2 m)))))).
 
 (* ! QuickChick comp_bop_correct_checker. *)
 
 Definition comp_bexp_correct_checker : Checker :=
-  forAll arbitrary (fun b: bexp => 
+  forAll arbitrary (fun b: bexp =>
     comp_correct_checker (comp_bexp b) (fun m => if (beval b m) then 1 else 0)).
 
 (* ! QuickChick comp_bexp_correct_checker. *)
 
 (** Exercise: Now write a checker for the following.
 
-Lemma comp_store_correct : 
+Lemma comp_store_correct :
   forall g a v le lr cs st,
   insns_at_pc g (block_entry le) (steval (comp_store a v lr) cs) ->
   st_pc st = (block_entry le) ->
@@ -86,7 +86,7 @@ Definition comp_store_correct_checker_inner'
       let new_dom := (v :: vst_mem_dom vst) in
       whenFail ("::: cfg is: " ++ show g ++
                 " ::: initial state pc: " ++ show (vst_pc vst) ++
-                " ::: le: " ++ show le ++ 
+                " ::: le: " ++ show le ++
                 " ::: lr: " ++ show lr ++
                 " ::: store to " ++ show v ++
                 " ::: curr pc: " ++ show (block_entry lr) ++
@@ -117,7 +117,7 @@ Definition comp_store_correct_checker_inner
   | inr st' =>
     if (eq_dec_pc (V.Opsem.st_pc st') (block_entry lr)) then
       let new_dom := (v :: vst_mem_dom vst) in
-      whenFail 
+      whenFail
         "comp_store_correct: memories mismatch"
         (memory_on_domain_checker new_dom
           (V.Opsem.st_mem st')
@@ -147,17 +147,17 @@ Definition comp_cond_correct_checker_inner
   let '(g, end_pc) :=
       wrap_code_in_cfg (block_entry le)
                        (Stmon.steval (comp_cond b l1 l2) cs) [] in
-  let l := (if beval b (V.Opsem.st_mem st) then l1 else l2) in  
+  let l := (if beval b (V.Opsem.st_mem st) then l1 else l2) in
   match (V.Opsem.eval_until_pc g st (block_entry l) 1000) with
   | inl err =>
-    whenFail 
+    whenFail
       ("::: cfg is: " ++ show g ++
        "::: comp_cond_correct: " ++ err ++
        "::: looking for pc: " ++ show end_pc
       )
       false
   | inr st' =>
-    if (eq_dec_pc (V.Opsem.st_pc st') (block_entry l)) then 
+    if (eq_dec_pc (V.Opsem.st_pc st') (block_entry l)) then
       whenFail "comp_store_correct: memories mismatch"
                (memory_on_domain_checker (vst_mem_dom vst)
                                          (V.Opsem.st_mem st)
@@ -178,14 +178,14 @@ Definition comp_cond_correct_checker : Checker :=
 
 *)
 
-(** *** NOT DONE 
+(** *** NOT DONE
 Definition match_config_checker
            (c: Imp.com) ((g, l1 l2): cfg * lbl * lbl)
   : Checker :=
   match c with
   | SKIP => whenFail "match_config: labels not equal for skip"
                     (eq_dec_lbl l1 l2)
-  | 
+  |
 
 
 Inductive match_config : Imp.com -> (cfg * lbl * lbl) -> Prop :=
@@ -247,7 +247,7 @@ Lemma simulation_step' :
 Lemma simulation_step' :
   forall c mem mem' st r,
   let '(c', mem') := Imp.step (c, mem) in
-  
+
 
   match_states g r (c, mem) st ->
   exists st',

--- a/vminus/Dom.v
+++ b/vminus/Dom.v
@@ -19,7 +19,7 @@ Require Import Util.
 
 (* ################################################################# *)
 (** * GRAPH *)
-(** Interface for a nonempty graph [t] with: 
+(** Interface for a nonempty graph [t] with:
      - a set of _vertices_ of type [V], defined by a membership predicate [Mem]
      - a distinguished _entry vertex_ [entry]
      - an _edge relation_ [Succ]
@@ -27,7 +27,7 @@ Require Import Util.
 
 Module Type GRAPH.
   Parameter Inline t V : Type.
-  
+
   Parameter Inline entry : t -> V.
   Parameter Inline Succ : t -> V -> V -> Prop.
   Parameter Inline Mem : t -> V -> Prop.
@@ -37,7 +37,7 @@ End GRAPH.
 (* ################################################################# *)
 (** * Specification of Dominators *)
 
-(** This is a relational specification of the graph dominance properties that 
+(** This is a relational specification of the graph dominance properties that
     is convenient for proofs and intuitively captures the definitions. *)
 
 Module Spec (Import G:GRAPH).
@@ -47,58 +47,58 @@ Module Spec (Import G:GRAPH).
     [path g v1 v2 vs] means that there is a sequence of vertices
     starting from vertex [v1] and ending at [v2] that are connected by
     the [Succ] relation.  The vertices traversed on the path are those
-    listed in [vs] (in reverse order).  
+    listed in [vs] (in reverse order).
 *)
 
   Inductive Path (g:G.t) : V -> V -> list V -> Prop :=
-  | path_nil : forall v, 
+  | path_nil : forall v,
       Mem g v -> Path g v v [v]
   | path_cons : forall v1 v2 v3 vs,
-      Path g v1 v2 vs -> Mem g v3 -> Succ g v2 v3 
+      Path g v1 v2 vs -> Mem g v3 -> Succ g v2 v3
       -> Path g v1 v3 (v3::vs).
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ----------------------------------------------------------------- *)
 (** *** Definition of domination *)
 
-  (** Vertex [v1] _dominates_ vertex [v2] if every path starting 
+  (** Vertex [v1] _dominates_ vertex [v2] if every path starting
       from the entry of the graph and ending at [v2] goes through [v1]. *)
-  
+
   Definition Dom (g:G.t) (v1 v2: V) : Prop :=
     forall vs, Path g (entry g) v2 vs -> In v1 vs.
 
-  (** Vertex [v1] _strictly dominates_ [v2] if they are distinct and 
+  (** Vertex [v1] _strictly dominates_ [v2] if they are distinct and
      [v1] dominates [v2] *)
-  
+
   Definition SDom (g:G.t) (v1 v2 : V) : Prop :=
     v1 <> v2 /\ Dom g v1 v2.
 
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ----------------------------------------------------------------- *)
 (** *** Interaction of dominance and Succ *)
 
   (** The strict dominators of a vertex [v2] also dominate its predecessors. *)
-  
+
   Lemma dom_step : forall g v1 v2,
     Mem g v2 -> Succ g v1 v2 -> forall v', SDom g v' v2 -> Dom g v' v1.
   Proof.
     unfold SDom, Dom. intros g v1 v2 Hmem Hsucc v' [Hneq Hdom] p Hp.
-    cut (In v' (v2::p)). inversion 1; subst; intuition. 
-    apply Hdom. eapply path_cons; eauto. 
+    cut (In v' (v2::p)). inversion 1; subst; intuition.
+    apply Hdom. eapply path_cons; eauto.
   Qed.
 
 End Spec.
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ################################################################# *)
 (** * Computing Dominance Properties *)
 
 (** As usual, if we want to run the dominance calculation, we need an executable
     version of the specification.  For dominance, we can think of an implementation
     as an function that takes a graph and produces a mapping that sends each
-    vertex to its set of strict dominators.  Any correct implementation must be sound 
-    (and complete) with respect to the relational spec defined above.  This 
+    vertex to its set of strict dominators.  Any correct implementation must be sound
+    (and complete) with respect to the relational spec defined above.  This
     interface capture the requirements of such an implementation.
 
     Full soundness follows from an "unrolled" version of the [dom_step] property.
@@ -120,7 +120,7 @@ Module Type Algdom (Import G:GRAPH).
 
   Axiom successors_sound : forall g sdom n1 n2,
     calc_sdom g = Some sdom ->
-    Mem g n1 -> Mem g n2 -> Succ g n1 n2 -> 
+    Mem g n1 -> Mem g n2 -> Succ g n1 n2 ->
     L.union (L.singleton n1) (sdom n1) <= sdom n2.
 
   Axiom complete : forall g sdom n1 n2,
@@ -129,7 +129,7 @@ Module Type Algdom (Import G:GRAPH).
 
 End Algdom.
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ################################################################# *)
 (** * Full Soundness *)
 
@@ -141,15 +141,15 @@ Module AlgdomProperties (Import G:GRAPH) (Import A : Algdom G).
   Module Import GS := Spec G.
 
   Lemma sound : forall g sdom n1 n2,
-    calc_sdom g = Some sdom ->              
+    calc_sdom g = Some sdom ->
     L.In n1 (sdom n2) -> Dom g n1 n2.
   Proof.
     red; intros. remember (entry g). induction H1. subst.
-    pose proof entry_sound g sdom H. 
+    pose proof entry_sound g sdom H.
 
     destruct (sdom (entry g)); try contradiction; simpl in *.
       exfalso. rewrite H2 in H0. eapply L.SFacts.empty_iff. eauto.
-      
+
     right. destruct (E.eq_dec v2 n1). subst. inversion H1; intuition.
     apply IHPath; auto.
 

--- a/vminus/DomKildall.v
+++ b/vminus/DomKildall.v
@@ -17,7 +17,7 @@ Require Import Dom Kildall Util.
 Require Import FSets FMaps.
 
 
-Module AlgdomKildall (PC:UsualDecidableType) 
+Module AlgdomKildall (PC:UsualDecidableType)
                      (Import G:GRAPH with Definition V := PC.t)
        : Algdom G.
 
@@ -27,7 +27,7 @@ Module AlgdomKildall (PC:UsualDecidableType)
 
 
   Module L := BoundedSet NS.
-  Module Import K := ! ForwardSolver N L.    Module NM := K.NM.                       
+  Module Import K := ! ForwardSolver N L.    Module NM := K.NM.
   (* Module Import FMP := FMapProps N NM. *)
   Module FMF := FMapFacts.WFacts_fun N NM.
   Module FSF := FSetFacts.WFacts_fun N NS.
@@ -61,7 +61,7 @@ Module AlgdomKildall (PC:UsualDecidableType)
     calc_sdom g = Some sdom ->
     sdom (entry g) == L.top.
   Proof.
-    unfold calc_sdom. intros. 
+    unfold calc_sdom. intros.
     destruct (K.fixpoint _ _ _) eqn:Heqk; try discriminate H.
     injection H. intro. clear H. subst sdom.
     set (r := t0!!(entry g)). cut (L.le L.top r).
@@ -76,7 +76,7 @@ Module AlgdomKildall (PC:UsualDecidableType)
 
   Lemma successors_sound : forall g sdom n1 n2,
     calc_sdom g = Some sdom ->
-    Mem g n1 -> Mem g n2 -> Succ g n1 n2 -> 
+    Mem g n1 -> Mem g n2 -> Succ g n1 n2 ->
     L.union (L.singleton n1) (sdom n1) <= sdom n2.
   Proof.
     unfold calc_sdom. intros.
@@ -86,15 +86,15 @@ Module AlgdomKildall (PC:UsualDecidableType)
     set (trans n o := L.union (L.singleton n) o).
     change (L.union (L.singleton n1) t0!!n1)
            with (trans n1 t0!!n1).
-    eapply K.fixpoint_solution. 
-    eauto. 
+    eapply K.fixpoint_solution.
+    eauto.
 
     unfold inits. destruct (N.eq_dec n1 (entry g)).
     apply FMF.add_in_iff; auto. apply FMF.add_neq_in_iff; auto.
 
     (* separate lemma? *)
     apply enum_vs_compat in H0. set (f g n := NM.add n L.bot g).
-    assert (In n1 (enum_vs g) \/ NM.In n1 (NM.empty L.t)) 
+    assert (In n1 (enum_vs g) \/ NM.In n1 (NM.empty L.t))
            as Hin by exact (or_introl H0).
     generalize (enum_vs g) (NM.empty L.t) Hin.
     induction l; simpl. intuition.
@@ -124,8 +124,8 @@ Module AlgdomKildall (PC:UsualDecidableType)
     eapply K.fixpoint_invariant; eauto.
 
     intros. destruct (N.eq_dec (entry g) n).
-    subst n. contradict H0. 
-    apply entry_not_sdom. unfold inits. 
+    subst n. contradict H0.
+    apply entry_not_sdom. unfold inits.
     rewrite FMP.find_default_neq; auto. unfold FMP.find_default.
     destruct (NM.find _ _) as [l'|] eqn:Heq; simpl; auto.
 
@@ -142,19 +142,19 @@ Module AlgdomKildall (PC:UsualDecidableType)
 
     pose proof (succs_compat2 _ _ _ H) as Hmem.
     apply succs_compat in H.
-    
+
     destruct ls eqn:Heqls, ln eqn:Heqln; simpl; auto.
     apply FSF.inter_iff. split. apply H1; auto.
     apply FSF.union_iff.
     destruct (N.eq_dec n1 n). left. apply FSF.singleton_iff; auto.
     right. apply H0. red; split; auto.
-    eapply dom_step with (v2:=s); auto. 
-    
+    eapply dom_step with (v2:=s); auto.
+
     apply H1; auto.
 
     apply FSF.union_iff.
     destruct (N.eq_dec n1 n). left. apply FSF.singleton_iff; auto.
-    right. apply H0. red; split; auto. 
+    right. apply H0. red; split; auto.
     eapply dom_step with (v2:=s); auto.
 
   Qed.

--- a/vminus/Env.v
+++ b/vminus/Env.v
@@ -15,8 +15,8 @@
 Require Import Equalities List.
 Set Implicit Arguments.
 
-(** An _environment_ maps values of type [K.t] to values of type 
-    V. This module implements updateable environments using Coq 
+(** An _environment_ maps values of type [K.t] to values of type
+    V. This module implements updateable environments using Coq
     functions and proves some simple facts about equality. *)
 
 Module Make_Env (K:UsualDecidableType).
@@ -34,7 +34,7 @@ Section WithV.
   Theorem update_eq : forall v k1 k2 st,
     K.eq k1 k2 -> (update st k1 v) k2 = v.
   Proof.
-    intros. unfold update. 
+    intros. unfold update.
     destruct (K.eq_dec k1 k2); intuition.
   Qed.
 
@@ -46,7 +46,7 @@ Section WithV.
   Qed.
 
   Theorem update_shadow : forall v1 v2 k1 k2 st,
-    K.eq k1 k2 -> 
+    K.eq k1 k2 ->
     (update (update st k1 v1) k1 v2) k2 = (update st k1 v2) k2.
   Proof.
     intros. unfold update.
@@ -56,11 +56,11 @@ Section WithV.
   Theorem update_same : forall v1 k1 k2 (st : t),
     st k2 = v1 -> (update st k1 v1) k2 = st k2.
   Proof.
-    intros. unfold update. 
+    intros. unfold update.
     destruct (K.eq_dec k1 k2); subst; reflexivity.
   Qed.
 
-  
+
 End WithV.
 End Make_Env.
 

--- a/vminus/Imp.v
+++ b/vminus/Imp.v
@@ -4,7 +4,7 @@
 (* ################################################################# *)
 (** * Imp: Simple Imperative Programs *)
 
-(** This file presents a variant of the Imp programming language 
+(** This file presents a variant of the Imp programming language
     adapted from the Software Foundations book.  It is the source
     language that will be compiled to the Vminus intermediate language
     in this development.
@@ -17,17 +17,17 @@ Require Import Vminus.Sequences.
 (* ----------------------------------------------------------------- *)
 (** *** Identifiers *)
 
-(** To simplify the compilation process, this variant of Imp uses 
+(** To simplify the compilation process, this variant of Imp uses
     [Atom.t] values as variable identifiers.  [Atom.t] is also used by
     the [Vminus] language, so making them the same avoids the need to
     use some kind of mapping from source to target identifiers.
 
     This is a slight deviation from the earlier presentation that took
-    [id] to be constructed via [Id : nat -> id].  
+    [id] to be constructed via [Id : nat -> id].
 
     The reason to use [Atom.t] is that this type supports the
     generation of "fresh" identifiers, a feature needed in
-    implementing a compiler.  
+    implementing a compiler.
 *)
 
 Definition id := Atom.t.
@@ -36,7 +36,7 @@ Definition id := Atom.t.
 (** *** Arithmetic expressions *)
 (** Arithmetic expressions are just the same as in Imp. *)
 
-Inductive aexp : Type := 
+Inductive aexp : Type :=
   | ANum   : nat -> aexp
   | AId    : id -> aexp
   | APlus  : aexp -> aexp -> aexp
@@ -49,7 +49,7 @@ Inductive aexp : Type :=
     we'll see) Vminus doesn't support boolean values natively, we'll
     have to compile these to natural numbers. *)
 
-Inductive bexp : Type := 
+Inductive bexp : Type :=
   | BTrue  : bexp
   | BFalse : bexp
   | BEq    : aexp -> aexp -> bexp
@@ -71,15 +71,15 @@ Inductive com : Type :=
 
 (* ----------------------------------------------------------------- *)
 (** *** Notation *)
-Notation "'SKIP'" := 
+Notation "'SKIP'" :=
   CSkip : imp_scope.
-Notation "X '::=' a" := 
+Notation "X '::=' a" :=
   (CAss X a) (at level 60) : imp_scope.
-Notation "c1 ;; c2" := 
+Notation "c1 ;; c2" :=
   (CSeq c1 c2) (at level 80, right associativity) : imp_scope.
-Notation "'WHILE' b 'DO' c 'END'" := 
+Notation "'WHILE' b 'DO' c 'END'" :=
   (CWhile b c) (at level 80, right associativity) : imp_scope.
-Notation "'IFB' e1 'THEN' e2 'ELSE' e3 'FI'" := 
+Notation "'IFB' e1 'THEN' e2 'ELSE' e3 'FI'" :=
   (CIf e1 e2 e3) (at level 80, right associativity) : imp_scope.
 
 (** *** An Example:
@@ -106,7 +106,7 @@ Definition update := @State.update nat.
 
 (* ----------------------------------------------------------------- *)
 (** *** Arithmetic evaluation *)
-(** Arithmetic and boolean expressions are evaluated in a given 
+(** Arithmetic and boolean expressions are evaluated in a given
     state. *)
 
 Fixpoint aeval (e : aexp) (st : state) : nat :=
@@ -122,7 +122,7 @@ Fixpoint aeval (e : aexp) (st : state) : nat :=
 (* ----------------------------------------------------------------- *)
 (** *** Boolean evaluation *)
 Fixpoint beval (e : bexp) (st : state) : bool :=
-  match e with 
+  match e with
   | BTrue       => true
   | BFalse      => false
   | BEq a1 a2   => beq_nat (aeval a1 st) (aeval a2 st)
@@ -148,7 +148,7 @@ Inductive step : (com * state) -> (com * state) -> Prop :=
     step (SKIP ;; c2, st) (c2, st)
 
 | S_IfTrue : forall st c1 c2 e,
-    beval e st = true -> 
+    beval e st = true ->
     step (IFB e THEN c1 ELSE c2 FI, st) (c1, st)
 
 | S_IfFalse : forall st c1 c2 e,
@@ -156,7 +156,7 @@ Inductive step : (com * state) -> (com * state) -> Prop :=
     step (IFB e THEN c1 ELSE c2 FI, st) (c2, st)
 
 | S_While : forall st c e,
-    step (WHILE e DO c END, st) 
+    step (WHILE e DO c END, st)
          (IFB e THEN (c ;; WHILE e DO c END) ELSE SKIP FI, st).
 
 
@@ -173,7 +173,7 @@ Fixpoint imp_eval (c: com) (st: state) (fuel: nat) : option state :=
     | c1 ;; c2 =>
       match c1 with
       | SKIP => imp_eval c2 st n'
-      | _ => 
+      | _ =>
         match imp_eval c1 st n' with
         | Some st' => imp_eval c2 st' n'
         | None => None

--- a/vminus/ImpGen.v
+++ b/vminus/ImpGen.v
@@ -58,7 +58,7 @@ Instance show_bexp: Show bexp :=
   {| show :=
        fix show_bexp_func b := (
          match b with
-         | BTrue => "true" 
+         | BTrue => "true"
          | BFalse => "false"
          | BEq a1 a2 => (show a1) ++ " = " ++ (show a2)
          | BLe a1 a2 => (show a1) ++ " <= " ++ (show a2)
@@ -140,14 +140,14 @@ Record imp_state : Type := mk_imp_state { imp_st: state; imp_dom: list Atom.t }.
 Definition gen_state_from_atom_list
            `{Gen nat}
            (atom_list : list Atom.t) : G state :=
-  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list => 
+  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list =>
   returnGen (fun (a : Atom.t) =>
                match (index_of_atom_in_list a atom_list) with
                | None => 0
                | Some i =>
                  List.nth i nat_list 0
                end)).
- 
+
 Instance gen_imp_state : GenSized imp_state :=
   {| arbitrarySized n :=
        let mem_dom := get_fresh_atoms n [] in
@@ -157,14 +157,14 @@ Instance gen_imp_state : GenSized imp_state :=
   |}.
 
 Definition show_image_given_domain `{Show A}
-           (f: Atom.t -> A) (l: list Atom.t) 
-           (prefix: string) : string := 
+           (f: Atom.t -> A) (l: list Atom.t)
+           (prefix: string) : string :=
   ((List.fold_left
       (fun accum atom =>
          accum ++ "(" ++ prefix ++ " " ++ (show atom) ++ ", "
                ++ show (f atom) ++ ") ")
       l "[") ++ "]")%string.
-                   
+
 Instance show_imp_state: Show imp_state :=
   {| show x :=
      "imp_state: " ++ (show_image_given_domain (imp_st x)

--- a/vminus/ImpProp.v
+++ b/vminus/ImpProp.v
@@ -13,7 +13,7 @@ Lemma imp_step_star_seq_append:
              imp_step_star (c1 ;; c, st1) (c2 ;; c, st2).
 Proof.
   intros p1 p2 imp_step_p1.
-  induction imp_step_p1 as 
+  induction imp_step_p1 as
       [[c1' st1'] | [c1' st1'] [c_step st_step] [c_final st_final]];
     intros c1 c2 c st st2 p1_eq p2_eq; inversion p1_eq; inversion p2_eq; subst.
   - apply star_refl.
@@ -30,7 +30,7 @@ Lemma imp_step_star_trans: forall c1 c2 st1 st2 st,
 Proof.
   intros c1 c2 st1 st2 st imp1 imp2; unfold imp_step_star in *.
   inversion imp1; subst.
-  - eapply star_step. 
+  - eapply star_step.
     apply S_SeqSkip.
     trivial.
   - apply star_trans with (b := (SKIP ;; c2, st)).
@@ -51,7 +51,7 @@ Lemma imp_step_star_seq_inversion:
 Proof.
   intros p1 p2 imp_step_p1.
   induction imp_step_p1 as [| [cseq' sta'] p [skip' stc'] Hstep];
-    intros c1 c2 sta stc p1_eq p2_eq; 
+    intros c1 c2 sta stc p1_eq p2_eq;
     try solve [rewrite p1_eq in p2_eq; inversion p2_eq].
   inversion p1_eq; inversion p2_eq; subst.
   clear p1_eq; clear p2_eq.
@@ -82,12 +82,12 @@ Proof.
       intros IH.
     inversion IH as [stb [imp1 imp2]].
     exists stb.
-    split; 
-      [eapply star_step; 
-       [apply step_c1_1 | apply imp1] | 
+    split;
+      [eapply star_step;
+       [apply step_c1_1 | apply imp1] |
        apply imp2].
   - inversion Hstep.
-    rename st' into one_step_after_sta; 
+    rename st' into one_step_after_sta;
       rename c1' into c1';
       rename H3 into step_c1;
       rename H0 into p_eq.
@@ -97,12 +97,12 @@ Proof.
       intros IH.
     inversion IH as [stb [imp1 imp2]].
     exists stb.
-    split; 
-      [eapply star_step; 
-       [apply step_c1 | apply imp1] | 
+    split;
+      [eapply star_step;
+       [apply step_c1 | apply imp1] |
        apply imp2].
   - inversion Hstep.
-    rename st' into one_step_after_sta; 
+    rename st' into one_step_after_sta;
       rename c1' into c1';
       rename H3 into step_c1;
       rename H0 into p_eq.
@@ -112,9 +112,9 @@ Proof.
       intros IH.
     inversion IH as [stb [imp1 imp2]].
     exists stb.
-    split; 
-      [eapply star_step; 
-       [apply step_c1 | apply imp1] | 
+    split;
+      [eapply star_step;
+       [apply step_c1 | apply imp1] |
        apply imp2].
 Qed.
 
@@ -122,7 +122,7 @@ Ltac cases_on_imp_eval :=
   match goal with
   | H: match ?imp_eval with
           | Some _ => _
-          | None => _ 
+          | None => _
        end = _ |- _ =>
     destruct imp_eval as [middle_st | ] eqn:middle_st_eq;
     try solve [inversion H]
@@ -153,13 +153,13 @@ Proof.
                  [apply imp_single_step |
                   apply IHn;
                   trivial]].
-  } 
+  }
   { simpl in eval_ok.
     destruct (beval b st) eqn:eval_b;
       apply IHn in eval_ok.
     - eapply star_step; [apply S_IfTrue; trivial | trivial].
-    - eapply star_step; [apply S_IfFalse; trivial | trivial].      
-  }      
+    - eapply star_step; [apply S_IfFalse; trivial | trivial].
+  }
   { simpl in eval_ok.
     destruct (beval b st) eqn:eval_b;
       try solve [inversion eval_ok].
@@ -171,5 +171,5 @@ Proof.
     eapply star_step; [apply S_While | idtac].
     eapply star_step; [apply S_IfTrue; trivial | idtac].
     apply (imp_step_star_seq_append _ _ after_one_iter); reflexivity.
-  }     
+  }
 Qed.

--- a/vminus/Iteration.v
+++ b/vminus/Iteration.v
@@ -26,7 +26,7 @@
 (** Bounded iterators *)
 
 (* we can get away with using unary nats in our toy compiler
-   Q: why does compcert use positive vs. binary nats? 
+   Q: why does compcert use positive vs. binary nats?
       how are they extracted -- extra cons for each number?
    binary nats are better supported in the stdlib*)
 
@@ -72,14 +72,14 @@ Lemma iter_prop:
   forall n b a, P a -> iter n a = Some b -> Q b.
 Proof.
   intros n b. pattern n. apply (well_founded_ind N.lt_wf_0).
-  intros until 2. rewrite (Fix_eq N.lt_wf_0 _ iter_step). 
-  unfold iter_step at 1. destruct (N.eq_dec _ _). 
+  intros until 2. rewrite (Fix_eq N.lt_wf_0 _ iter_step).
+  unfold iter_step at 1. destruct (N.eq_dec _ _).
   discriminate 1. specialize (step_prop H0).
   destruct (step a).
     inversion 1; subst b0; exact step_prop.
     apply H; auto. apply N.lt_pred_l; auto.
-  intros. f_equal. 
-  apply functional_extensionality_dep. intro. 
+  intros. f_equal.
+  apply functional_extensionality_dep. intro.
   apply functional_extensionality_dep. auto.
 Qed.
 

--- a/vminus/Kildall.v
+++ b/vminus/Kildall.v
@@ -23,11 +23,11 @@
  ---------------------------------------------------------------------------- *)
 
 (* Acknowledgements --------------------------------------------------------- *)
-(* 
+(*
   This file is heavily based on:
-      - lib/Lattice.v 
-      - backend/Kildall.v 
-  from the CompCert development,  modified to remove dependencies and 
+      - lib/Lattice.v
+      - backend/Kildall.v
+  from the CompCert development,  modified to remove dependencies and
   optimizations.
 *)
 
@@ -45,11 +45,11 @@ Module Type FORWARD_SOLVER.
   Module FMP := FMapProps N NM.
 
   Include EqLeNotation L.
-  Notation "a !! b" := (FMP.find_default a b L.bot) 
+  Notation "a !! b" := (FMP.find_default a b L.bot)
                          (at level 1, format "a !! b").
   Notation nlmap := (NM.t L.t).
 
-  Parameter fixpoint: forall 
+  Parameter fixpoint: forall
     (succs: N.t -> list N.t)
     (trans: N.t -> L.t -> L.t)
     (inits: nlmap),
@@ -68,8 +68,8 @@ Module Type FORWARD_SOLVER.
   Axiom fixpoint_invariant : forall succs trans inits
     (P: N.t -> L.t -> Prop)
     (Pinits: forall n, P n inits!!n)
-    (Ptrans: forall n ln s ls, 
-      In s (succs n) -> 
+    (Ptrans: forall n ln s ls,
+      In s (succs n) ->
       P n ln -> P s ls -> P s (L.join ls (trans n ln))),
     forall res n, fixpoint succs trans inits = Some res -> P n res!!n.
 
@@ -81,7 +81,7 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
 
   Module L := LAT.
   Module N := PC.
-  
+
   Include EqLeNotation L.
 
   (* TODO: can define a total order for PCs to use more efficient sets/maps *)
@@ -104,27 +104,27 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
   Definition prop_succ (out:L.t) (s:state) (n:N.t) : state :=
     let oldl := s.(lmap)!!n in
     let newl := L.join oldl out in
-    if L.eq_dec oldl newl 
+    if L.eq_dec oldl newl
     then s else mkst (NM.add n newl s.(lmap)) (n::s.(wlist)).
 
   Definition step (s:state) : NM.t L.t + state :=
     match s.(wlist) with
       | nil => inl s.(lmap)
-      | n::rem => 
+      | n::rem =>
         inr (fold_left (prop_succ (trans n s.(lmap)!!n))
                        (succs n) (mkst s.(lmap) rem))
     end.
 
   Definition make_init_state : state :=
     mkst inits (map (@fst _ _) (NM.elements inits)).
-  
+
   Definition fixpoint := Iter.iterate step make_init_state.
 
 
   (* correctness *)
 
   Definition n_invar (s:state) (n:N.t) : Prop :=
-    In n s.(wlist) \/ forall m, In m (succs n) -> 
+    In n s.(wlist) \/ forall m, In m (succs n) ->
       trans n s.(lmap)!!n <= s.(lmap)!!m.
 
   Definition state_invar (s:state) : Prop :=
@@ -138,10 +138,10 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     destruct (L.eq_dec _ _). apply H.
     destruct H. simpl; intuition.
       destruct (N.eq_dec n n').
-        simpl; intuition. right. intros. 
+        simpl; intuition. right. intros.
         destruct (N.eq_dec n' m); subst s'; simpl.
-          rewrite find_default_neq, find_default_eq; auto. 
-            transitivity (lmap s)!!m. apply H; auto. 
+          rewrite find_default_neq, find_default_eq; auto.
+            transitivity (lmap s)!!m. apply H; auto.
             subst n'; apply L.le_join_l.
           rewrite find_default_neq, find_default_neq; auto.
   Qed.
@@ -163,14 +163,14 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
   Lemma step_state_invar : forall s s',
     state_invar s -> inr s' = step s -> state_invar s'.
   Proof.
-    unfold step, state_invar; intros s s' Hinv Hstep. 
+    unfold step, state_invar; intros s s' Hinv Hstep.
     destruct (wlist s) eqn:Hwls. discriminate Hstep.
     injection Hstep; clear Hstep. intros Heqs' n.
 
     destruct (N.eq_dec t n).
 
     (* n_invar is restablished for n *)
-    subst t. unfold n_invar. 
+    subst t. unfold n_invar.
     destruct(in_dec N.eq_dec n (wlist s')) as [|Hwl]; [auto | right].
     intros m Hin. rewrite prop_n_out; eauto; simpl.
     generalize Hwl; clear Hwl. pattern s', m.
@@ -179,7 +179,7 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
       intros a b b'.
       set (r := prop_succ _ a b').
       intros. unfold prop_succ in r. destruct (L.eq_dec _ _). apply H0; auto.
-      unfold r. simpl. destruct (N.eq_dec b' b). 
+      unfold r. simpl. destruct (N.eq_dec b' b).
         rewrite find_default_eq; auto. apply L.le_join_r.
         rewrite find_default_neq; auto. apply H0. contradict Hwl; simpl; auto.
 
@@ -195,7 +195,7 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     unfold state_invar, n_invar in Hinv |- *.
     simpl. specialize (Hinv n). rewrite Hwls in Hinv. destruct Hinv.
     assumption. left. destruct H; intuition. right. apply H.
-  Qed. 
+  Qed.
 
   Lemma fixpoint_solution: forall res n s,
     fixpoint = Some res ->
@@ -203,21 +203,21 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     In s (succs n) ->
     trans n res!!n <= res!!s.
   Proof.
-    unfold fixpoint; intros. pattern res. 
-    eapply Iter.iter_prop with 
+    unfold fixpoint; intros. pattern res.
+    eapply Iter.iter_prop with
       (step:=step) (P:=state_invar) (a:=make_init_state); eauto.
     intros a Ha.
-    unfold step. destruct (wlist a) eqn:Heql. 
-    specialize (Ha n). destruct Ha. 
+    unfold step. destruct (wlist a) eqn:Heql.
+    specialize (Ha n). destruct Ha.
       auto. rewrite Heql in *. contradiction. auto.
 
-    eapply step_state_invar. apply Ha. 
+    eapply step_state_invar. apply Ha.
     unfold step. rewrite Heql. auto.
 
     left. simpl. apply in_map_iff.
     pose proof (NMFacts.elements_in_iff inits n0) as [He _].
     specialize (He H2). destruct He as [e Hine].
-    apply InA_alt in Hine as [y [Heq Hk]]. 
+    apply InA_alt in Hine as [y [Heq Hk]].
     inversion Heq; eauto.
   Qed.
 
@@ -227,10 +227,10 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     forall n, nl1!!n <= nl2!!n.
 
   Lemma le_nlmap_refl : forall nl, le_nlmap nl nl.
-  Proof. 
-    unfold le_nlmap. reflexivity. 
+  Proof.
+    unfold le_nlmap. reflexivity.
   Qed.
-  
+
   Instance le_nlmap_trans : Transitive le_nlmap.
     unfold Transitive, le_nlmap; intros. transitivity y !! n; auto.
   Qed.
@@ -245,7 +245,7 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     unfold le_nlmap, prop_succ; intros.
     destruct (L.eq_dec _ _). reflexivity.
     simpl. destruct (N.eq_dec n n0).
-      subst. rewrite find_default_eq; auto. 
+      subst. rewrite find_default_eq; auto.
       rewrite find_default_neq; auto. reflexivity.
   Qed.
 
@@ -253,24 +253,24 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     inr st' = step st ->
     le_nlmap st.(lmap) st'.(lmap).
   Proof.
-    unfold step; intros. destruct (wlist st). 
+    unfold step; intros. destruct (wlist st).
     discriminate. injection H. intro Heqs.
     pattern st'. eapply fold_left_1.
-    intros. transitivity (lmap a). 
+    intros. transitivity (lmap a).
       assumption. apply prop_succ_le_nlmap.
     apply Heqs. apply le_nlmap_refl.
   Qed.
-    
+
   Lemma fixpoint_entry : forall res n,
     fixpoint = Some res -> inits!!n <= res!!n.
   Proof.
     unfold fixpoint. intros. pattern res.
     eapply Iter.iter_prop with (step:=step). intros.
-    destruct (step a) eqn:Hstep. 
+    destruct (step a) eqn:Hstep.
     unfold step in Hstep. destruct (wlist a); try discriminate.
-    injection Hstep. intro; subst t. apply H0. 
-    simpl in *. transitivity (lmap a)!!n. auto. 
-    apply step_le_nlmap. auto. 
+    injection Hstep. intro; subst t. apply H0.
+    simpl in *. transitivity (lmap a)!!n. auto.
+    apply step_le_nlmap. auto.
     change inits with (lmap make_init_state).
     cbv beta. reflexivity. apply H.
   Qed.
@@ -279,16 +279,16 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     (P: N.t -> L.t -> Prop)
     (Pinits: forall n, P n inits!!n)
     (Ptrans: forall n ln s ls,
-      In s (succs n) -> 
+      In s (succs n) ->
       P n ln -> P s ls -> P s (L.join ls (trans n ln))),
     forall res n, fixpoint = Some res -> P n res!!n.
   Proof.
     intros until 2.
-    unfold fixpoint. intros. pattern res. 
+    unfold fixpoint. intros. pattern res.
     eapply Iter.iter_prop with (step:=step); eauto.
 
     intro. destruct (step a) eqn:Hstep.
-    
+
     (* last step  Q implies P *)
     unfold step in Hstep. destruct (wlist a); try discriminate.
     instantiate (1:=fun s => forall n, P n s.(lmap)!!n).
@@ -298,13 +298,13 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
     simpl. intros. unfold step in Hstep.
     destruct (wlist a); try discriminate.
     injection Hstep; clear Hstep; intro Heqs.
-    
+
     pattern s. eapply fold_left_1 with (f:=prop_succ _); eauto.
-    intros. unfold prop_succ. 
+    intros. unfold prop_succ.
     destruct (L.eq_dec _ _); simpl; auto.
     destruct (N.eq_dec b n0).
-    rewrite find_default_eq; auto. 
-      subst b. apply Ptrans; auto. 
+    rewrite find_default_eq; auto.
+      subst b. apply Ptrans; auto.
     rewrite find_default_neq; auto.
     auto.
   Qed.
@@ -313,4 +313,4 @@ Module ForwardSolver (PC:UsualDecidableType) (LAT:LATTICE):
 
 End ForwardSolver.
 
-  
+

--- a/vminus/OpSemGen.v
+++ b/vminus/OpSemGen.v
@@ -19,14 +19,14 @@ Import V.Opsem.
 Generalizable All Variables.
 
 Definition show_image_given_domain `{Show A}
-           (f: Atom.t -> A) (l: list Atom.t) 
-           (prefix: string) : string := 
+           (f: Atom.t -> A) (l: list Atom.t)
+           (prefix: string) : string :=
   ((List.fold_left
       (fun accum atom =>
          accum ++ "(" ++ prefix ++ " " ++ (show atom) ++ ", "
                ++ show (f atom) ++ ") ")
       l "[") ++ "]")%string.
-                   
+
 (** Opsem **)
 
 Definition show_memory
@@ -54,7 +54,7 @@ Record vminus_state : Type :=
 
 Definition gen_loc_from_atom_list
            (atom_list : list Atom.t) : G loc :=
-  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list => 
+  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list =>
   returnGen (fun (a : Atom.t) =>
                match (index_of_atom_in_list a atom_list) with
                | None => None
@@ -64,7 +64,7 @@ Definition gen_loc_from_atom_list
 
 Definition gen_mem_from_atom_list
            (atom_list : list Atom.t) : G mem :=
-  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list => 
+  bindGen (vectorOf (List.length atom_list) arbitrary) (fun nat_list =>
   returnGen (fun (a : Atom.t) =>
                match (index_of_atom_in_list a atom_list) with
                | None => 0
@@ -136,7 +136,7 @@ Definition generate_dummy_insns n: list insn :=
   in List.rev (helper n).
 
 (* TODO: proper generator *)
-(* Returns a CFG with a single block containing instrs ++ instrs_after, 
+(* Returns a CFG with a single block containing instrs ++ instrs_after,
     and the pc in that block that begins at instrs_after *)
 Definition wrap_code_in_cfg (p: pc) (instrs instrs_after: list insn)
   : ListCFG.t * pc :=

--- a/vminus/Sequences.v
+++ b/vminus/Sequences.v
@@ -1,8 +1,8 @@
-(* 
-  Acknowledgements:  
-  This file is taken from the compiler verification development created by 
+(*
+  Acknowledgements:
+  This file is taken from the compiler verification development created by
 
-    Xavier Leroy, INRIA Paris-Rocquencourt                    
+    Xavier Leroy, INRIA Paris-Rocquencourt
 
   and available at: http://gallium.inria.fr/~xleroy/courses/Eugene-2012/
 *)
@@ -57,7 +57,7 @@ Lemma plus_star:
   forall a b,
   plus a b -> star a b.
 Proof.
-  intros. inversion H. eapply star_step; eauto. 
+  intros. inversion H. eapply star_step; eauto.
 Qed.
 
 Lemma plus_star_trans:
@@ -69,7 +69,7 @@ Qed.
 Lemma plus_star_trans':
   forall a b c, star a b -> plus b c -> plus a c.
 Proof.
-  intros. inversion H. auto. apply plus_star in H0. 
+  intros. inversion H. auto. apply plus_star in H0.
   eapply plus_left. eauto. eapply star_trans; eauto.
 Qed.
 
@@ -78,7 +78,7 @@ Lemma star_plus_trans:
   forall a b c, star a b -> plus b c -> plus a c.
 Proof.
   intros. inversion H0. inversion H. econstructor; eauto.
-  econstructor; eauto. eapply star_trans; eauto. econstructor; eauto. 
+  econstructor; eauto. eapply star_trans; eauto. econstructor; eauto.
 Qed.
 
 Lemma plus_right:
@@ -101,12 +101,12 @@ Definition all_seq_inf (a: A) : Prop :=
   from [a], there exists one infinite sequence of transitions
   [a --> a1 --> a2 --> ... -> aN -> ...].
 
-  Indeed, consider [A = nat] and [R] such that [R 0 0] and [R 0 1].  
+  Indeed, consider [A = nat] and [R] such that [R 0 0] and [R 0 1].
   [all_seq_inf 0] does not hold, because a sequence [0 -->* 1] cannot be extended.
-  Yet, [R] admits an infinite sequence, namely [0 --> 0 --> ...].  
+  Yet, [R] admits an infinite sequence, namely [0 --> 0 --> ...].
 
-  Another attempt would be to represent the sequence of states 
-  [a0 --> a1 --> a2 --> ... -> aN -> ...] explicitly, as a function 
+  Another attempt would be to represent the sequence of states
+  [a0 --> a1 --> a2 --> ... -> aN -> ...] explicitly, as a function
   [f: nat -> A] such that [f i] is the [i]-th state [ai] of the sequence. *)
 
 Definition infseq_with_function (a: A) : Prop :=
@@ -138,7 +138,7 @@ CoInductive infseq: A -> Prop :=
 
   The [infseq] predicate above must be defined coinductively.  Indeed, if
   we define it inductively, the predicate would be empty (always false),
-  since there are no base cases!  
+  since there are no base cases!
 
   Coq provides some primitive support for constructing infinite derivations
   of facts such as [infseq a].  Such constructions are proofs by coinduction.
@@ -151,7 +151,7 @@ Proof.
 Qed.
 
 (** This style of proof by coinduction, using the [cofix] tactic, is effective
-  but can run into limitations of Coq's proof engine (the so-called 
+  but can run into limitations of Coq's proof engine (the so-called
   "guard condition").  However, we can derive more conventional
   coinduction principles that are often easier to use. *)
 
@@ -168,7 +168,7 @@ Lemma infseq_coinduction_principle:
   forall a, X a -> infseq a.
 Proof.
   intros X P. cofix COINDHYP; intros.
-  destruct (P a H) as [b [U V]]. apply infseq_step with b; auto. 
+  destruct (P a H) as [b [U V]]. apply infseq_step with b; auto.
 Qed.
 
 (** An even more useful variant of this coinduction principle considers a
@@ -183,10 +183,10 @@ Proof.
   intros.
   apply infseq_coinduction_principle with
     (X := fun a => exists b, star a b /\ X b).
-  intros. 
+  intros.
   destruct H1 as [b [STAR Xb]]. inversion STAR; subst.
   destruct (H b Xb) as [c [PLUS Xc]]. inversion PLUS; subst.
-  exists b0; split. auto. exists c; auto. 
+  exists b0; split. auto. exists c; auto.
   exists b0; split. auto. exists b; auto.
 
   exists a; split. apply star_refl. auto.
@@ -200,8 +200,8 @@ Lemma infseq_if_all_seq_inf:
   forall a, all_seq_inf a -> infseq a.
 Proof.
   apply infseq_coinduction_principle.
-  intros. destruct (H a) as [b Rb]. constructor. 
-  exists b; split; auto. 
+  intros. destruct (H a) as [b Rb]. constructor.
+  exists b; split; auto.
   unfold all_seq_inf; intros. apply H. apply star_step with b; auto.
 Qed.
 
@@ -214,14 +214,14 @@ Proof.
   apply infseq_coinduction_principle.
   intros. destruct H as [f [P Q]].
   exists (f 1); split.
-  subst a. apply Q. 
+  subst a. apply Q.
   exists (fun n => f (1 + n)); split. auto. intros. apply Q.
 Qed.
- 
+
 (** Consider the transition sequences starting at state [a].
   They can be infinite, or they can be finite: after a number of transitions,
   we reach a state from with no transition is possible.  It is intuitively
-  obvious that at least one of the two cases must hold. 
+  obvious that at least one of the two cases must hold.
 
   It is however impossible to prove this fact in Coq's constructive logic.
   Indeed, a constructive proof would be isomorphic (by the Curry-Howard isomorphism)
@@ -265,8 +265,8 @@ Lemma star_star_inv:
 Proof.
   induction 1; intros.
   auto.
-  inversion H1; subst. right. eapply star_step; eauto. 
-  assert (b = b0). eapply R_functional; eauto. subst b0. 
+  inversion H1; subst. right. eapply star_step; eauto.
+  assert (b = b0). eapply R_functional; eauto. subst b0.
   apply IHstar; auto.
 Qed.
 
@@ -286,7 +286,7 @@ Qed.
 Lemma infseq_star_inv:
   forall a b, star a b -> infseq a -> infseq b.
 Proof.
-  induction 1; intros. auto. 
+  induction 1; intros. auto.
   inversion H1; subst. assert (b = b0). eapply R_functional; eauto. subst b0.
   apply IHstar. auto.
 Qed.
@@ -295,9 +295,9 @@ Lemma infseq_finseq_excl:
   forall a b,
   star a b -> irred b -> infseq a -> False.
 Proof.
-  intros. 
-  assert (infseq b). eapply infseq_star_inv; eauto. 
-  inversion H2. elim (H0 b0); auto. 
+  intros.
+  assert (infseq b). eapply infseq_star_inv; eauto.
+  inversion H2. elim (H0 b0); auto.
 Qed.
 
 (** If there exists an infinite sequence of transitions from [a],
@@ -306,14 +306,14 @@ Qed.
 Lemma infseq_all_seq_inf:
   forall a, infseq a -> all_seq_inf a.
 Proof.
-  intros. unfold all_seq_inf. intros. 
-  assert (infseq b). eapply infseq_star_inv; eauto. 
+  intros. unfold all_seq_inf. intros.
+  assert (infseq b). eapply infseq_star_inv; eauto.
   inversion H1. subst. exists b0; auto.
 Qed.
 
 End SEQUENCES.
 
 
-  
+
 
 

--- a/vminus/Stmon.v
+++ b/vminus/Stmon.v
@@ -26,10 +26,10 @@ Section STMON.
   Definition bind2 (A B C:Type) (f:stmon (A * B)) (g:A -> B -> stmon C) : stmon C :=
     fun s => let '(s', (a, b)) := f s in g a b s'.
 
-  Definition stget : stmon S := 
+  Definition stget : stmon S :=
     fun s => (s, s).
 
-  Definition stput (s:S) : stmon unit := 
+  Definition stput (s:S) : stmon unit :=
     fun _ => (s, tt).
 
   Definition stmod (f:S -> S) : stmon unit :=
@@ -54,19 +54,19 @@ Section STMON.
 
   Lemma stmon_left_id : forall A B (a:A) (f: A -> stmon B),
     bind (ret a) f = f a.
-  Proof. 
-    intros. unfold bind, ret. 
+  Proof.
+    intros. unfold bind, ret.
     change (f a) with (fun s => f a s) at 2; auto.
   Qed.
 
   Lemma stmon_right_id : forall A (a:A) (ma:stmon A),
     bind ma ret = ma.
-  Proof. 
+  Proof.
     intros. extensionality s. unfold bind, ret.
     destruct (ma s); reflexivity.
   Qed.
 
-  Lemma stmon_assoc : 
+  Lemma stmon_assoc :
     forall A B C (m:stmon A) (f:A -> stmon B) (g:B -> stmon C),
     bind m (fun a => bind (f a) g) = bind (bind m f) g.
   Proof.
@@ -86,7 +86,7 @@ Notation "'do' X <- A ; B" := (bind A (fun X => B))
   (at level 200, X ident, A at level 100, B at level 200) : stmon_scope.
 
 Notation "'do' ( X , Y ) <- A ; B" := (bind2 A (fun X Y => B))
-  (at level 200, X ident, Y ident, A at level 100, B at level 200, 
+  (at level 200, X ident, Y ident, A at level 100, B at level 200,
   format "'do'  ( X ,  Y )  <-  A  ;  B") : stmon_scope.
 
 Delimit Scope stmon_scope with stmon.

--- a/vminus/Util.v
+++ b/vminus/Util.v
@@ -39,7 +39,7 @@ Section LIST.
     Nth a l n ->
     n < length l.
   Proof.
-    induction l. destruct n; simpl; intuition.  
+    induction l. destruct n; simpl; intuition.
     destruct n; simpl; intuition.
     apply Lt.lt_n_S. eapply IHl; eauto.
   Qed.
@@ -47,7 +47,7 @@ Section LIST.
   Lemma length_Nth : forall l n,
     n < length l ->
     exists a, Nth a l n.
-  Proof. 
+  Proof.
     induction l. inversion 1.
     intros. destruct n. simpl; eauto.
     simpl. apply IHl. auto with arith.
@@ -92,12 +92,12 @@ Section LIST.
   Lemma Nth_map : forall a l n f,
       Nth a l n -> Nth (f a) (map f l) n.
   Proof.
-    intros a. 
+    intros a.
     induction l.
     - intros. simpl in *. apply H.
     - simpl. destruct n; intros. rewrite H. reflexivity. apply IHl. apply H.
   Qed.
-      
+
 End LIST.
 
 Section NODUP.
@@ -113,7 +113,7 @@ Section NODUP.
     intros.
     induction l. inversion H0.
     destruct H0, H1. subst a. injection H1; auto.
-    inversion H; subst. apply in_map with (f:=@fst _ _) in H1. contradiction. 
+    inversion H; subst. apply in_map with (f:=@fst _ _) in H1. contradiction.
     inversion H; subst. apply in_map with (f:=@fst _ _) in H0. contradiction.
     apply IHl; auto. simpl in H. inversion H; auto.
   Qed.
@@ -137,10 +137,10 @@ Section NODUP.
   Lemma NoDup_app : forall (l l':list A),
     NoDup (l ++ l') -> NoDup l /\ NoDup l'.
   Proof.
-    induction l; simpl; intros. auto using NoDup_nil. 
-    inversion H; subst. 
+    induction l; simpl; intros. auto using NoDup_nil.
+    inversion H; subst.
     apply IHl in H3. destruct H3. split.
-      eapply NoDup_cons. contradict H2. apply in_or_app. 
+      eapply NoDup_cons. contradict H2. apply in_or_app.
       auto. auto. auto.
   Qed.
 
@@ -148,9 +148,9 @@ Section NODUP.
     NoDup (l1 ++ l2) ->
     In a l1 -> ~ In a l2.
   Proof.
-    intros. 
+    intros.
     apply in_split in H0 as [l11 [l12 Heql]].
-    rewrite Heql in H. rewrite <- app_assoc, <- app_comm_cons in H. 
+    rewrite Heql in H. rewrite <- app_assoc, <- app_comm_cons in H.
     apply NoDup_remove_2 in H. contradict H.
     rewrite app_assoc. apply in_or_app. auto.
   Qed.
@@ -176,7 +176,7 @@ Section FOLDS.
     exfalso. eapply NoDup_split; eauto.
     apply (in_flat_map f l b). eexists; eauto.
     eapply NoDup_app in H as [? ?].
-    apply IHl; auto. 
+    apply IHl; auto.
   Qed.
 
   Lemma NoDup_flat_map__NoDup : forall (A B:Type) (a:A) (f:A -> list B) l,
@@ -191,11 +191,11 @@ Section FOLDS.
 
   Lemma fold_left_1 : forall  (P:A -> Prop) (f:A -> B -> A) (bs : list B)
     (Hpres : forall a b, In b bs -> P a -> P (f a b)),
-    forall a a', 
+    forall a a',
       a' = fold_left f bs a -> P a -> P a'.
   Proof.
     intros. subst a'. generalize dependent a.
-    induction bs; simpl; intros. assumption. 
+    induction bs; simpl; intros. assumption.
     apply IHbs. intros. apply Hpres. right; auto. assumption.
     apply Hpres. left; auto. assumption.
   Qed.
@@ -204,7 +204,7 @@ Section FOLDS.
     (f:A -> B -> A)
     (Hpres : forall a b b', P a b -> P (f a b') b)
     (Hintr : forall a b, P (f a b) b),
-    forall a a' bs b, 
+    forall a a' bs b,
     a' = fold_left f bs a ->
     In b bs -> P a' b.
   Proof.
@@ -212,7 +212,7 @@ Section FOLDS.
     induction bs as [|b']. contradiction.
     simpl; intros. destruct H0. subst b'.
     set (a' := fold_left _ _ _). pattern a'.
-    eapply fold_left_1; eauto. reflexivity. 
+    eapply fold_left_1; eauto. reflexivity.
     apply IHbs. assumption.
   Qed.
 
@@ -245,7 +245,7 @@ Section ASSOC.
   Proof.
     induction l. inversion 1.
     intros. destruct a as [a b']. simpl.
-    destruct (eq_dec a0 a). eauto. 
+    destruct (eq_dec a0 a). eauto.
     destruct H. contradict n; inversion H; auto.
     eapply IHl; eauto.
   Qed.
@@ -268,7 +268,7 @@ Section ASSOC.
         * inversion H.
         * apply IHl. exact H.
   Qed.
-  
+
 End ASSOC.
 
 Require Import FSets FMaps.
@@ -278,7 +278,7 @@ Module FMapProps (E:UsualDecidableType) (M:FMapInterface.WSfun E).
   Local Notation K := M.key.
 
   Section FMapProps.
-  
+
   Variable V : Type.
 
   Definition find_default (m:M.t V) (k:K) (d:V) : V :=
@@ -294,7 +294,7 @@ Module FMapProps (E:UsualDecidableType) (M:FMapInterface.WSfun E).
     intros. unfold find_default.
     destruct (M.find n2 (M.add _ _ _)) eqn:Heq1, (M.find n2 m) eqn:Heq2.
     apply M.find_2 in Heq1. apply M.add_3 in Heq1; auto. apply M.find_1 in Heq1.
-      rewrite Heq2 in Heq1. injection Heq1. auto. 
+      rewrite Heq2 in Heq1. injection Heq1. auto.
     apply M.find_2 in Heq1. apply M.add_3 in Heq1; auto. apply M.find_1 in Heq1.
       rewrite Heq2 in Heq1. discriminate Heq1.
     apply M.find_2 in Heq2. eapply M.add_2 in Heq2; eauto. apply M.find_1 in Heq2.
@@ -320,7 +320,7 @@ Module Type LATTICE.
   Declare Instance eq_equiv : Equivalence eq.
   Declare Instance le_preorder : PreOrder le.
   Declare Instance le_poset : PartialOrder eq le.
-  
+
   Parameter eq_dec : forall x y, {x == y} + {x ~= y}.
 
   Parameter bot : t.
@@ -368,7 +368,7 @@ Module BoundedSet(Import S:FSetInterface.WS) <: LATTICE.
   Instance le_preorder : PreOrder le.
   Proof.
     constructor.
-    red. destruct x; simpl; intuition. 
+    red. destruct x; simpl; intuition.
     red. destruct x, y, z; simpl; intros; intuition.
     transitivity t1; auto.
   Qed.
@@ -377,13 +377,13 @@ Module BoundedSet(Import S:FSetInterface.WS) <: LATTICE.
   Proof.
     constructor.
     intro. repeat red. split.
-    destruct x, x0; simpl in *; intuition. 
+    destruct x, x0; simpl in *; intuition.
     unfold Subset. intros. rewrite H; auto.
     red. destruct x, x0; simpl in *; intuition.
     unfold Subset. intros. rewrite <- H. auto.
 
-    destruct x, x0; simpl; 
-      intros H; repeat red in H; simpl in H; 
+    destruct x, x0; simpl;
+      intros H; repeat red in H; simpl in H;
       intuition.
     repeat red in H1. repeat red in H0.
     red; intuition.
@@ -406,14 +406,14 @@ Module BoundedSet(Import S:FSetInterface.WS) <: LATTICE.
 
   Definition top : t := Some S.empty.
   Lemma le_top : forall x, x <= top.
-  Proof. 
+  Proof.
     simpl. destruct x; trivial. red. intros.
-    exfalso. eapply empty_iff; eauto. 
+    exfalso. eapply empty_iff; eauto.
   Qed.
 
   Definition join (t1 t2: t) : t :=
     match t1, t2 with
-      | Some s1, Some s2 => Some (S.inter s1 s2) 
+      | Some s1, Some s2 => Some (S.inter s1 s2)
       | None, Some s | Some s, None => Some s
       | None, None => None
     end.
@@ -432,11 +432,11 @@ Module BoundedSet(Import S:FSetInterface.WS) <: LATTICE.
 
   Definition union (t1 t2: t) : t :=
     match t1, t2 with
-      | Some s1, Some s2 => Some (S.union s1 s2) 
+      | Some s1, Some s2 => Some (S.union s1 s2)
       | None, Some s | Some s, None => None
       | None, None => None
     end.
-    
+
   Definition singleton (e:S.elt) : t := Some (S.singleton e).
 
   Definition In (e:S.elt) (t:t) : Prop :=

--- a/vminus/Vminus.v
+++ b/vminus/Vminus.v
@@ -43,7 +43,7 @@ Notation uid := Uid.t.
 
 (** Addresses of mutable state *)
 
-Module Addr := Atom. 
+Module Addr := Atom.
 Notation addr := Addr.t.
 
 (** All come equipped with decidable equality. *)
@@ -81,14 +81,14 @@ Hint Resolve eq_dec_val.
     instructions.
 *)
 
-Inductive bop : Set := 
+Inductive bop : Set :=
  | bop_add   (* addition *)
  | bop_sub   (* subtraction *)
  | bop_mul   (* multiplication *)
  | bop_eq    (* equality *)
  | bop_le    (* less-than-or-equal *)
  | bop_and   (* both non-zero *)
-.  
+.
 
 Definition eq_dec_bop : forall (b1 b2:bop), {b1 = b2} + {b1 <> b2}.
 Proof.
@@ -103,7 +103,7 @@ Hint Resolve eq_dec_bop.
 (** * Basic block terminators *)
 
 (** Each basic block is a sequence of commands (defined next) ending
-    in a _terminator_, which is just a control flow operation.  
+    in a _terminator_, which is just a control flow operation.
     Terminators cannot appear in the middle of a well-formed basic block.
     (We will define well-formed Vminus programs later.)
 *)
@@ -124,7 +124,7 @@ Hint Resolve eq_dec_tmn.
 (* ################################################################# *)
 (** * Commands *)
 
-(** Vminus has only a few commands: binary operations, 
+(** Vminus has only a few commands: binary operations,
     terminators, phi nodes, and [load] and [store] operations. *)
 
 (** Each [phiarg] associates a value with a predessor block, given by
@@ -136,7 +136,7 @@ Definition eq_dec_phiarg:
   forall phiarg1 phiarg2: phiarg, {phiarg1 = phiarg2} + {phiarg1 <> phiarg2}.
 Proof.
   decide equality.
-Defined.  
+Defined.
 Instance eq_phiarg : eq_dec phiarg := eq_dec_phiarg.
 Hint Resolve eq_dec_phiarg.
 
@@ -146,7 +146,7 @@ Proof.
   decide equality.
 Defined.
 Hint Resolve eq_dec_list_phiarg.
-    
+
 (** Vminus Commands *)
 
 Inductive cmd : Set :=
@@ -159,15 +159,15 @@ Inductive cmd : Set :=
 Definition eq_dec_cmd: forall cmd1 cmd2: cmd, {cmd1 = cmd2} + {~(cmd1 = cmd2)}.
 Proof.
   decide equality.
-Defined.  
+Defined.
 Instance eq_cmd : eq_dec cmd := eq_dec_cmd.
 Hint Resolve eq_dec_cmd.
 
 (** An instruction associates a unique local identifier with one of the
     above commands. The local identifier serves two purposes:
 
-    - it uniquely identifies this occurrence of the command 
-    - it serves as the value 
+    - it uniquely identifies this occurrence of the command
+    - it serves as the value
 
 
 *)
@@ -178,7 +178,7 @@ Definition eq_dec_insn:
   forall insn1 insn2: insn, {insn1 = insn2} + {~(insn1 = insn2)}.
 Proof.
   decide equality.
-Defined. 
+Defined.
 Instance eq_insn : eq_dec insn := eq_dec_insn.
 Hint Resolve eq_dec_insn.
 
@@ -198,7 +198,7 @@ Definition insn_uses (i:insn) : list val :=
 
 (** Which labels appear in an instruction? *)
 Definition insn_lbls (i:insn) : list lbl :=
-  match i with 
+  match i with
     | (_, cmd_tmn (tmn_jmp l)) => [l]
     | (_, cmd_tmn (tmn_cbr _ l1 l2)) => [l1; l2]
     | _ => []
@@ -212,18 +212,18 @@ Definition insn_phis (i:insn) : list phiarg :=
   end.
 
 (** Is it a terminator? *)
-Definition is_tmn (i:insn) : Prop := 
+Definition is_tmn (i:insn) : Prop :=
   match i with (_, cmd_tmn _) => True | _ => False end.
 
 (** Is is a phi node? *)
-Definition is_phi (i:insn) : Prop := 
+Definition is_phi (i:insn) : Prop :=
   match i with (_, cmd_phi _) => True | _ => False end.
 
 Lemma is_phi_decidable : forall i, {is_phi i} + {~is_phi i}.
 Proof.
   intros [? c].
   destruct c; simpl; tauto.
-Qed.  
+Qed.
 
 (** Does it define its uid? *)
 Definition defs_uid (i:insn) : Prop :=

--- a/vminus/VminusGen.v
+++ b/vminus/VminusGen.v
@@ -27,7 +27,7 @@ Instance shrink_lbl : Shrink lbl := {| shrink x := [] |}.
 Instance show_lbl : Show lbl :=
   {| show x :=
        ("lbl "%string ++ show x ++ "")%string |}.
-  
+
 Instance gen_uid : Gen uid :=
   {| arbitrary := gen_fresh fresh_store |}.
 
@@ -101,7 +101,7 @@ Proof. unfold pc. auto with typeclass_instances. Defined.
 Instance show_pc : Show pc :=
   {| show p :=
        let '(lbl, offset) := p in
-       "(blk " ++ (show lbl) ++ ", ofs " 
+       "(blk " ++ (show lbl) ++ ", ofs "
                ++ show_nat offset ++ ")"
   |}.
 

--- a/vminus/VminusOpSem.v
+++ b/vminus/VminusOpSem.v
@@ -23,13 +23,13 @@ Require Import Vminus.CFG.
     too.  Once we have established that the two semantics correspond,
     it is easy to prove that the relational semantics is deterministic
     because it is equivalent to the executable semantics, which is
-    given by a function.  
-    
+    given by a function.
+
     The development is parameterized by a control-flow graph, making
     the operational semantics independent of its representation.
 
     Later, as a demonstration of using these semantics, we will prove
-    the correctness of an Imp to Vminus compiler and some program  
+    the correctness of an Imp to Vminus compiler and some program
     transformations as the Vminus level.
 *)
 
@@ -42,15 +42,15 @@ Module Opsem.
   (**  ------------------------------------------------------------------------- *)
   (** *** The state of a Vminus program: *)
 
-  (** The local environment is a _partial_ map from [uid]s to 
+  (** The local environment is a _partial_ map from [uid]s to
       natural numbers. *)
-  
+
   Module Locals := Make_Env(Uid).
   Notation loc := (Locals.t (option nat)).
   Notation update := Locals.update.
 
-  (** The Vminus memory is a _total_ map from addresses to 
-      natural numbers.  (This is a bit artificial, but is a simplification 
+  (** The Vminus memory is a _total_ map from addresses to
+      natural numbers.  (This is a bit artificial, but is a simplification
       that aligns with the variant of Imp we use in this development.)
   *)
 
@@ -61,19 +61,19 @@ Module Opsem.
       current program counter.  It also remembers the environment
       in effect at the end of the of the predecessor block, for
       use in phi instructions (see below). *)
-  
+
   Record state := mkst { st_mem  : mem
                        ; st_pc   : pc
                        ; st_loc  : loc
                        ; st_ppc  : pc     (* predecessor pc *)
-                       ; st_ploc : loc    (* predecessor locals *) 
+                       ; st_ploc : loc    (* predecessor locals *)
                        }.
 
   (**  ------------------------------------------------------------------------- *)
   (** *** Evaluating values. *)
 
   (** Simply look up the uid in the local environment. (May fail!) *)
-  
+
   Definition eval_val (loc:loc) (v:val) : option nat :=
     match v with
       | val_nat n => Some n
@@ -98,22 +98,22 @@ Module Opsem.
 
   Definition eval_bop (loc:loc) (bop:bop) (v1 v2:val) : option nat :=
     match eval_val loc v1, eval_val loc v2 with
-      | Some n1, Some n2 => Some (bop_denote bop n1 n2) 
+      | Some n1, Some n2 => Some (bop_denote bop n1 n2)
       | _, _ => None
     end.
 
   (**  ------------------------------------------------------------------------- *)
   (** *** Evaluating phi nodes *)
-  (** To evaluate a phi instruction, we need to know from which 
+  (** To evaluate a phi instruction, we need to know from which
       predecessor block control reached this phi node, as well as
       the local environment in effect at the end of that block.
-      
-      We look up the value associated with the predecessor label 
-      in the phi arg list, and interpret it in the predecessor's 
+
+      We look up the value associated with the predecessor label
+      in the phi arg list, and interpret it in the predecessor's
       local environment, which are supplied to [eval_phi].
   *)
 
-  Definition eval_phi (ploc:loc) (pl:lbl) (pas:list phiarg) 
+  Definition eval_phi (ploc:loc) (pl:lbl) (pas:list phiarg)
     : option nat :=
     match assoc Lbl.eq_dec pl pas with
       | Some v => eval_val ploc v
@@ -122,7 +122,7 @@ Module Opsem.
 
   (**  ------------------------------------------------------------------------- *)
   (** *** Control transfers *)
-  
+
   (** Given the current locals and the terminator, determine
       the label of the next block to jump to (if any). *)
 
@@ -145,26 +145,26 @@ Module Opsem.
   | step_bop : forall mem pc loc bop v1 v2 uid n ppc ploc,
       insn_at_pc g pc (uid, cmd_bop bop v1 v2) ->
       Some n = eval_bop loc bop v1 v2 ->
-      step g (mkst mem pc loc ppc ploc) 
-             (mkst mem (incr_pc pc) 
+      step g (mkst mem pc loc ppc ploc)
+             (mkst mem (incr_pc pc)
                        (update loc uid (Some n)) ppc ploc)
 
-  (** Evaluate the right-hand side in the predecessor's 
-     local environment. [lbl_of ppc] is the source block of the 
+  (** Evaluate the right-hand side in the predecessor's
+     local environment. [lbl_of ppc] is the source block of the
      control-flow edge that we jumped from to reach the current block. *)
 
   | step_phi : forall mem pc loc pas uid n ppc ploc,
       insn_at_pc g pc (uid, cmd_phi pas) ->
       Some n = eval_phi ploc (lbl_of ppc) pas ->
       step g (mkst mem pc loc ppc ploc)
-             (mkst mem (incr_pc pc) 
+             (mkst mem (incr_pc pc)
                        (update loc uid (Some n)) ppc ploc)
 
-  (** Find the successor block (if any), update the pc. 
+  (** Find the successor block (if any), update the pc.
       Record the current pc and locals as the "predecessor" state
       for use by any [phi] nodes in the successor block. *)
 
-  | step_tmn : forall mem pc l' loc tmn uid ppc ploc, 
+  | step_tmn : forall mem pc l' loc tmn uid ppc ploc,
       insn_at_pc g pc (uid, cmd_tmn tmn) ->
       Some l' = eval_tmn loc tmn ->
       step g (mkst mem pc loc ppc ploc)
@@ -175,14 +175,14 @@ Module Opsem.
   | step_load : forall mem pc loc uid addr ppc ploc,
       insn_at_pc g pc (uid, cmd_load addr) ->
       step g (mkst mem pc loc ppc ploc)
-             (mkst mem (incr_pc pc) 
+             (mkst mem (incr_pc pc)
                        (update loc uid (Some (mem addr))) ppc ploc)
 
   | step_store : forall mem pc loc uid addr v n ppc ploc,
       insn_at_pc g pc (uid, cmd_store addr v) ->
       Some n = eval_val loc v ->
       step g (mkst mem pc loc ppc ploc)
-             (mkst (Memory.update mem addr n) 
+             (mkst (Memory.update mem addr n)
                    (incr_pc pc) loc ppc ploc).
 
 
@@ -190,10 +190,10 @@ Module Opsem.
  (** *** Definition of the initial state. *)
 
  (** The initial state starts with the program counter at the beginning of the
-     entry block in an empty environment.  The "predecessor state" can be 
-     set arbitrarily -- we will prove that in any well-formed CFG, the 
+     entry block in an empty environment.  The "predecessor state" can be
+     set arbitrarily -- we will prove that in any well-formed CFG, the
      entry block cannot have any phi nodes. *)
-  
+
   Definition init_state (g:Cfg.t) (m: mem) : state :=
     (mkst m
           (block_entry (entry_block g))
@@ -202,37 +202,37 @@ Module Opsem.
           (Locals.empty None)).
 
 
-  (**  ------------------------------------------------------------------------- *)  
+  (**  ------------------------------------------------------------------------- *)
   (** * Small-step, executable operational semantics *)
 
-  (** This version of the semantics is just a straight forward interpreter, 
-      implemented monadically in an error monad to deal with partiality. 
-       
+  (** This version of the semantics is just a straight forward interpreter,
+      implemented monadically in an error monad to deal with partiality.
+
       It uses [fetch] where the relational specification uses [insn_at_pc], but
       is otherwise a fairly direct transliteration of the relational version.
 
-      Note: the monad notation and definitions come from [Classes.v], a 
+      Note: the monad notation and definitions come from [Classes.v], a
       general purpose library that collects together some commonly used
       typeclasses and instances.
 
-      - [mret] is the "return" of a monad    
+      - [mret] is the "return" of a monad
       - the notation  ['x <- e1; e2] is the "bind"
       - [trywith] lifts the [option] monad into the [err] monad
   *)
-  (**  ------------------------------------------------------------------------- *)  
-  
+  (**  ------------------------------------------------------------------------- *)
+
   Fixpoint eval_step (g : Cfg.t) (s : state) : err state :=
     let 'mkst mem pc loc ppc ploc := s in
-    '(uid, insn) <- trywith "no instruction fetched" (Cfg.fetch g pc); 
+    '(uid, insn) <- trywith "no instruction fetched" (Cfg.fetch g pc);
     match insn with
-    | cmd_bop bop v1 v2 =>    
+    | cmd_bop bop v1 v2 =>
       'n <- trywith "cannot evalute binop command"  (eval_bop loc bop v1 v2);
       mret (mkst mem (incr_pc pc) (update loc uid (Some n)) ppc ploc)
 
     | cmd_phi pas =>
       'n <- trywith "cannot evaluate phi" (eval_phi ploc (lbl_of ppc) pas);
       mret (mkst mem (incr_pc pc) (update loc uid (Some n)) ppc ploc)
-           
+
     | cmd_tmn tmn =>
       'l' <- trywith "cannot evaluate terminator" (eval_tmn loc tmn);
       mret (mkst mem (block_entry l') loc pc loc)
@@ -244,8 +244,8 @@ Module Opsem.
       'n <- trywith "cannot evaluate address to store to" (eval_val loc v);
         mret (mkst (Memory.update mem addr n) (incr_pc pc) loc ppc ploc)
     end.
-  
-  (**  ------------------------------------------------------------------------- *)  
+
+  (**  ------------------------------------------------------------------------- *)
   (** *** Helper functions for many-steps of evaluation *)
 
   Fixpoint eval_until_pc (g : Cfg.t) (s : state)
@@ -272,20 +272,20 @@ Module Opsem.
     eval_until_pc g s' target_pc fuel.
 
 
-  (**  ------------------------------------------------------------------------- *)  
+  (**  ------------------------------------------------------------------------- *)
   (** ** Correspondence between relational and executable definitions *)
 
   (** Given that the relational and executable semantics share most of their "core"
-      functionality, it is pretty easy to prove that the two are equivalent.  
+      functionality, it is pretty easy to prove that the two are equivalent.
    *)
-  
-  (** This tactic helps drive the evaluator by looking for a hypothesis that is 
+
+  (** This tactic helps drive the evaluator by looking for a hypothesis that is
       "stuck" on a [trywith] because it can't be simplified without further case
-      analysis.  The tactic destructs the blocking expression, and is able to 
+      analysis.  The tactic destructs the blocking expression, and is able to
       automatically discharge the goal by applying one of the [step] constructors,
       which is provided as an argument.
   *)
-  
+
   Ltac eval_step_with_step next_state constructor_rule
        cfg_well_formed fetched :=
     match goal with
@@ -314,7 +314,7 @@ Module Opsem.
   Proof.
     intros g s s' wf_g; unfold eval_step;
       destruct s as [mem curr_pc curr_loc previous_pc previous_loc];
-      destruct (Cfg.fetch g curr_pc) as 
+      destruct (Cfg.fetch g curr_pc) as
           [[uid [bop v1 v2 | pas | term | addr | addr v]] | ] eqn:fetched; simpl;
       intros H;
       [eval_step_with_step s' step_bop wf_g fetched |
@@ -323,7 +323,7 @@ Module Opsem.
        eval_step_with_step s' step_load wf_g fetched |
        eval_step_with_step s' step_store wf_g fetched | inversion H].
   Qed.
-  
+
   Lemma evaluator_complete: forall g s s',
       Cfg.wf_cfg g -> step g s s' -> eval_step g s = inr s'.
   Proof.
@@ -339,7 +339,7 @@ Module Opsem.
     try rewrite insn_at_pc_is; simpl;
     try rewrite <- eval_insn_ok; try reflexivity.
   Qed.
-  
+
   Theorem evaluator_correct: forall g s s',
       Cfg.wf_cfg g -> eval_step g s = inr s' <-> step g s s'.
   Proof.
@@ -349,18 +349,18 @@ Module Opsem.
     apply evaluator_complete.
   Qed.
 
-(** ------------------------------------------------------------------------- *)  
+(** ------------------------------------------------------------------------- *)
 (* ################################################################# *)
 (** * Determinism of [step] *)
 
-(** A direct consequence of the equivalence between the relational and 
-    functional specifications is that we can prove that [step] is 
-    deterministic.  
+(** A direct consequence of the equivalence between the relational and
+    functional specifications is that we can prove that [step] is
+    deterministic.
 
     Note: one can prove that [step] is deterministic _without_ using the
     correspondence with the evaluator, but it requires significantly more work!
     It might be informative to try doing that proof. *)
-  
+
 Lemma step_deterministic : forall g s s1 s2, wf_cfg g ->
   step g s s1 -> step g s s2 -> s1 = s2.
 Proof.
@@ -371,21 +371,21 @@ Proof.
 Qed.
 
 
-  
+
 End Opsem.
 End Make.
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ================================================================= *)
 (** ** Instantiating the operational semantics to ListCFG *)
 
 (** For interesting applications of the operational semantics, such as building
     a compiler or writing program transformations, we need to pick a concrete
-    representation of the CFG module.  For this development, we use the 
+    representation of the CFG module.  For this development, we use the
     [ListCFG] definition.
  *)
 
 Require Vminus.ListCFG.
 Module Import V := Make ListCFG.ListCFG.
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)

--- a/vminus/VminusStatics.v
+++ b/vminus/VminusStatics.v
@@ -22,7 +22,7 @@ Import Cfg.
     constraints ensure that each instruction only mentions local
     identifiers that are in scope according to the domination
     structure of the control-flow graph and that all mentioned labels
-    are associated with blocks defined in the CFG.  
+    are associated with blocks defined in the CFG.
 
     These properties are partly enforced by the "syntactic"
     well-formedness constraints imposed by the CFG interface (see
@@ -37,22 +37,22 @@ Import Cfg.
 
 *)
 
-Module Typing.  
-(**  ------------------------------------------------------------------------- *)  
+Module Typing.
+(**  ------------------------------------------------------------------------- *)
 (* ################################################################# *)
 (** * GRAPH instance for dominance calculation *)
 
 (** We need to define an graph instance that captures all the edges
     of our CFGs.
-    
+
     - vertices in the graph are just program points
 
     - program points _within_ a single block have "fallthrough" edges determined by incrementing the program counter
-    
-    - a block [b1] terminated by a branch to [b2] induces an edge from [b1] to [b2] in the CFG.  
+
+    - a block [b1] terminated by a branch to [b2] induces an edge from [b1] to [b2] in the CFG.
   *)
 
-  
+
   (** Graph edge relation *)
 
   Inductive succ_pc (g:Cfg.t) : pc -> pc -> Prop :=
@@ -63,7 +63,7 @@ Module Typing.
       In l (insn_lbls i) ->
       succ_pc g p (block_entry l).
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ################################################################# *)
 (** * GRAPH instance for dominance calculation *)
 
@@ -78,44 +78,44 @@ Module Typing.
   End PcGraph.
 
 (** Instantiate the dominance spec for this graph *)
-  
+
   Module Export Dom := Dom.Spec PcGraph.
 
-  
-(**  ------------------------------------------------------------------------- *)  
+
+(**  ------------------------------------------------------------------------- *)
 (* ################################################################# *)
 (** * Defining SSA scoping *)
-  
+
 (** We can now use the dominance properties of the CFG to define scoping
     for well-formed SSA programs. We first need some auxliary predicates: *)
 
 (** The command at the given [pc] defines uid. *)
 
   Definition def_at_pc (g:Cfg.t) (p:pc) (uid:uid) : Prop :=
-    exists c, insn_at_pc g p (uid, c) /\ defs_uid (uid, c). 
+    exists c, insn_at_pc g p (uid, c) /\ defs_uid (uid, c).
 
   (** The [uid] has a definition that strictly dominates the pc [p]. *)
- 
+
   Definition uid_sdom_pc (g:Cfg.t) (uid:uid) (p:pc) : Prop :=
     exists p', def_at_pc g p' uid /\ SDom g p' p.
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ----------------------------------------------------------------- *)
 (** *** Uses are dominated by their definitions *)
-  
+
   (** All uses of a [uid] must be strictly dominated by
       their definitions. However, we have to treat [phi] instructions
-      specially, since the "uses" of identifiers on the right-hand side of 
-      are conditioned on control flow.  
+      specially, since the "uses" of identifiers on the right-hand side of
+      are conditioned on control flow.
 
       The right-hand-side of a phi node can safely refer to the identifier defined
       by the phi node itself.  For example, consider this snippet of code:
  [[
       entry:
-        br blk      
+        br blk
 
-      blk: 
-        %x = phi [%entry: 0] [%blk: %x]    
+      blk:
+        %x = phi [%entry: 0] [%blk: %x]
         br blk
  ]]
 
@@ -126,11 +126,11 @@ Module Typing.
     ~is_phi i -> forall uid, In (val_uid uid) (insn_uses i) -> uid_sdom_pc g uid p.
 
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
   (** *** Well-formed phi nodes *)
 
   (**  Consider [ %x = phi [lbl1:v1, ...,lbln:vn] ].  This is well formed
-       when every predecessor block with terminator program point p' 
+       when every predecessor block with terminator program point p'
        has a label associated with value v.  Moreover, if v is a uid then
        the definition of the uid strictly dominates p' (i.e. the terminator
        of the predecessor).
@@ -139,12 +139,12 @@ Module Typing.
   Definition wf_phi_args (g:Cfg.t) (i:insn) (p:pc) : Prop :=
     forall pred, succ_pc g pred (entry_of_pc p) ->
       (exists v, In (lbl_of pred, v) (insn_phis i)) /\
-      (forall uid, In (lbl_of pred, val_uid uid) (insn_phis i) -> 
+      (forall uid, In (lbl_of pred, val_uid uid) (insn_phis i) ->
           uid_sdom_pc g uid pred).
 
   (** Moreover, we require that fore every labeled value appearing in the
       right-hand side, there is a predecessor block with that label. *)
-  
+
   Definition wf_phi_pred (g:Cfg.t) (i:insn) (p:pc) : Prop :=
     forall l v, In (l, v) (insn_phis i) ->
       (exists pred, succ_pc g pred (entry_of_pc p) /\ lbl_of pred = l).
@@ -154,10 +154,10 @@ Module Typing.
              /\ wf_phi_pred g i p
              /\ insn_phis i <> [].
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
   (** *** Well-formed terminators *)
 
-  (** All jump targets must be legal block labels. *)  
+  (** All jump targets must be legal block labels. *)
 
   Definition wf_lbl (g:Cfg.t) (i:insn) : Prop :=
     forall l, In l (insn_lbls i) -> wf_pc g (block_entry l).
@@ -165,8 +165,8 @@ Module Typing.
 
   Definition reachable (g:Cfg.t) (p:pc) : Prop :=
     exists path, Path g (block_entry (entry_block g)) p path.
-  
-(**  ------------------------------------------------------------------------- *)  
+
+(**  ------------------------------------------------------------------------- *)
 (* ----------------------------------------------------------------- *)
 (** *** Well-formed instructions *)
 
@@ -188,7 +188,7 @@ Module Typing.
 
 End Typing.
 
-(**  ------------------------------------------------------------------------- *)  
+(**  ------------------------------------------------------------------------- *)
 (* ################################################################# *)
 (** * Type Safety *)
 
@@ -196,10 +196,10 @@ End Typing.
     and _progress_ theorems.  *)
 
 Module OpsemCorrect.
-  Module Import V := Make (Cfg).  
+  Module Import V := Make (Cfg).
   Import Typing Opsem.
 
-  
+
 
 
   (** *** Dominance relation *)
@@ -215,18 +215,18 @@ Module OpsemCorrect.
     uid_sdom_pc g uid' pc2 ->
     uid_sdom_pc g uid' pc1.
   Proof.
-    unfold uid_sdom_pc. 
-    intros g uid' uid pc1 pc2 c Hwff Hneq Hpc Hsucc Hi [pc' [Hdef Hdom]]. 
-    exists pc'. split. assumption. 
+    unfold uid_sdom_pc.
+    intros g uid' uid pc1 pc2 c Hwff Hneq Hpc Hsucc Hi [pc' [Hdef Hdom]].
+    exists pc'. split. assumption.
     split. contradict Hneq. subst pc'.
     inversion Hwff.
-    destruct Hdef as [? [? ?]]; eapply eq_pc_uid; eauto. 
-    inversion Hwff; eapply dom_step; eauto. 
+    destruct Hdef as [? [? ?]]; eapply eq_pc_uid; eauto.
+    inversion Hwff; eapply dom_step; eauto.
   Qed.
 
   (** ** Progress & Preservation *)
 
-  (** Extend well-formedness definitions to include all components of 
+  (** Extend well-formedness definitions to include all components of
   the state. *)
 
   Definition wf_loc (g:Cfg.t) (p:pc) (loc:loc) : Prop :=
@@ -239,19 +239,19 @@ Module OpsemCorrect.
   | wf_state_intro : forall st
       (Hwfpc: wf_pc g st.(st_pc))
       (Hwfloc: wf_loc g st.(st_pc) st.(st_loc))
-      (Hwfppc: at_entry g st.(st_pc) \/ 
+      (Hwfppc: at_entry g st.(st_pc) \/
                  succ_pc g st.(st_ppc) (entry_of_pc st.(st_pc)))
-      (Hwfploc: at_entry g st.(st_pc) \/ 
+      (Hwfploc: at_entry g st.(st_pc) \/
                   wf_loc g st.(st_ppc) st.(st_ploc)),
       wf_state g st.
 
   (** Initial state is well formed *)
 
-  Lemma wf_init_state : 
+  Lemma wf_init_state :
     forall g m, wf_prog g ->
     wf_state g (init_state g m).
   Proof.
-    intros g m Hprog. inversion Hprog. 
+    intros g m Hprog. inversion Hprog.
     apply wf_entry in Hwfcfg.
     econstructor. auto.
     red. simpl. intros. red in H. destruct H as [? [? [? ?]]].
@@ -273,7 +273,7 @@ Module OpsemCorrect.
     insn_at_pc g st.(st_pc) i ->
     ~ is_phi i.
    Proof.
-     intros g st i Hprog Hentry Hinsn. 
+     intros g st i Hprog Hentry Hinsn.
      destruct Hprog as [_ ? _ ?].
 
      specialize (Hwfis _ _ Hinsn). inversion Hwfis; subst.
@@ -281,7 +281,7 @@ Module OpsemCorrect.
      destruct (insn_phis i) eqn:His. contradiction H2; auto.
      assert (In p (insn_phis i)) as Hin. rewrite His. left; auto.
      destruct p. apply H1 in Hin. destruct Hin as [pred [Hpred Ht0]].
-     specialize (Hwfentry pred). contradict Hwfentry. 
+     specialize (Hwfentry pred). contradict Hwfentry.
      rewrite <- Hentry; auto.
    Qed.
 
@@ -296,13 +296,13 @@ Module OpsemCorrect.
     In v (insn_uses i) ->
     exists n, eval_val loc v = Some n.
   Proof.
-    intros ? ? ? ? v Hwff Hwfloc Hnotphi Hi ?. 
+    intros ? ? ? ? v Hwff Hwfloc Hnotphi Hi ?.
     destruct v as [uid | n].
-    simpl. inversion Hwff as [_ ? _]. apply Hwfis in Hi. 
+    simpl. inversion Hwff as [_ ? _]. apply Hwfis in Hi.
     destruct Hi as [? ? Huse].
     destruct (is_phi_decidable i).
     - contradiction.
-    specialize (Huse Hnotphi uid). 
+    specialize (Huse Hnotphi uid).
     lapply Huse; auto.
     simpl; eauto.
   Qed.
@@ -311,7 +311,7 @@ Module OpsemCorrect.
 
   Definition FinalState (g:Cfg.t) (s:state) : Prop :=
     exists uid, insn_at_pc g s.(st_pc) (uid, cmd_tmn tmn_ret).
-  
+
   Lemma progress : forall g s,
     wf_prog g -> wf_state g s ->
     FinalState g s \/ exists s', step g s s'.
@@ -319,22 +319,22 @@ Module OpsemCorrect.
     intros g s Hwff Hwfs.
     inversion Hwfs as [? Hwfpc]; subst. inversion Hwff.
     pose proof (wf_pc_insn g Hwfcfg _ Hwfpc) as [[i c] Hi].
-    rename s into j. set (s:=j) in *. destruct j. 
+    rename s into j. set (s:=j) in *. destruct j.
     destruct c.
-  
+
     - (* Case "cmd_bop". *)
     eelim (eval_val__wf_loc) with (v:=v) (loc:=st_loc0); eauto; simpl; auto.
     eelim (eval_val__wf_loc) with (v:=v0) (loc:=st_loc0); eauto; simpl; auto.
     intros n1 Heqn1 n2 Heqn2.
     right. eexists. eapply step_bop; eauto. unfold eval_bop.
-    rewrite Heqn1, Heqn2. reflexivity. 
+    rewrite Heqn1, Heqn2. reflexivity.
 
     - (* Case "cmd_phi". *)
     right. specialize (Hwfis _ _ Hi). inversion Hwfis; subst.
-    
-    destruct Hwfppc as [|Hwfppc]. 
+
+    destruct Hwfppc as [|Hwfppc].
     exfalso; eapply at_entry_not_phi; eauto. simpl; trivial.
-    destruct Hwfploc as [|Hwfploc]. 
+    destruct Hwfploc as [|Hwfploc].
     exfalso; eapply at_entry_not_phi; eauto. simpl; trivial.
 
     destruct (Hphi I) as [Hphi2 _]. clear Hphi.
@@ -344,11 +344,11 @@ Module OpsemCorrect.
     cut (exists n, eval_val st_ploc0 v' = Some n). intros [n Hn].
     eexists. eapply step_phi. eauto. unfold eval_phi.
     rewrite Hv. rewrite Hn. reflexivity.
-  
-    destruct v' as [i' | n']. simpl in *. apply Hwfploc. apply Hdom. 
+
+    destruct v' as [i' | n']. simpl in *. apply Hwfploc. apply Hdom.
     eapply assoc_in. apply Hv. simpl; eauto.
     eapply in_assoc_some. apply Hin.
-  
+
     - (* Case "cmd_tmn". *)
     destruct t0.
     * (*  SCase "tmn_jmp". *)
@@ -357,7 +357,7 @@ Module OpsemCorrect.
     * (* SCase "tmn_cbr". *)
       cut (exists n, eval_val st_loc0 v = Some n). intros [n Heqn].
       right. eexists. eapply step_tmn. eauto. simpl. rewrite Heqn. reflexivity.
-      eapply eval_val__wf_loc; eauto; simpl; auto. 
+      eapply eval_val__wf_loc; eauto; simpl; auto.
 
     * (* SCase "tmn_ret". *)
       left. unfold FinalState. eexists. eauto.
@@ -366,7 +366,7 @@ Module OpsemCorrect.
     right. eexists. apply step_load. eauto.
 
     - (* Case "cmd_store". *)
-    right. cut (exists n1, eval_val st_loc0 v = Some n1). 
+    right. cut (exists n1, eval_val st_loc0 v = Some n1).
     intros [n1 Heqn1]. eexists. eapply step_store. eauto. eauto.
     eapply eval_val__wf_loc; eauto; simpl; auto.
   Qed.
@@ -380,11 +380,11 @@ Module OpsemCorrect.
     ~ is_tmn i ->
     wf_pc g (incr_pc p).
   Proof.
-    intros. inversion H. 
+    intros. inversion H.
     apply (wf_pc_tmn g Hwfcfg) in H0 as [pt [Ht Hle]].
     eapply wf_pc_le_tmn; eauto.
     inversion Hle; subst. destruct H0.
-    contradict H2. eapply Hwftmn; eauto. 
+    contradict H2. eapply Hwftmn; eauto.
     constructor; auto with arith.
   Qed.
 
@@ -394,7 +394,7 @@ Module OpsemCorrect.
     intros.
     destruct t0; simpl in *.
     inversion H; auto.
-    destruct (eval_val loc v). injection H. 
+    destruct (eval_val loc v). injection H.
       destruct n; eauto.
       discriminate H. discriminate H.
   Qed.
@@ -409,12 +409,12 @@ Module OpsemCorrect.
     succ_pc g p1 p2 ->
     uid_sdom_pc g uid p2 ->
     uid_sdom_pc g uid p1.
-  Proof. 
+  Proof.
     destruct i; intros. inversion H4 as [? [[? [? Ht]] ?]].
-    eapply uid_sdom_step; eauto. 
-    contradict Ht. subst t0. assert (x = p1). 
+    eapply uid_sdom_step; eauto.
+    contradict Ht. subst t0. assert (x = p1).
     inversion H; eapply uid_at_pc_inj; try red; eauto. subst x.
-    replace (uid, x0) with (uid, c); trivial. 
+    replace (uid, x0) with (uid, c); trivial.
     inversion H; eapply insn_at_pc_func; eauto.
   Qed.
 
@@ -429,7 +429,7 @@ Module OpsemCorrect.
     intros. red; intros. destruct (Uid.eq_dec uid0 uid). subst.
     rewrite Locals.update_eq; eauto. reflexivity.
     rewrite Locals.update_neq; eauto. apply H3.
-    eapply uid_sdom_step; eauto. 
+    eapply uid_sdom_step; eauto.
   Qed.
 
   (** ** Preservation *)
@@ -441,7 +441,7 @@ Module OpsemCorrect.
     intros g _ s' Hwff [s Hwfpc Hwfloc] Hstep.
     inversion Hstep; subst; simpl in *;
       rename pc into pc0.
-    
+
     - (* Case "step_bop". *)
     assert (wf_pc g (incr_pc pc0)) as Hwfpc' by (eapply wf_pc_incr; eauto).
     constructor; simpl; try solve [destruct pc0; auto].
@@ -451,11 +451,11 @@ Module OpsemCorrect.
     assert (wf_pc g (incr_pc pc0)) as Hwfpc' by (eapply wf_pc_incr; eauto).
     constructor; simpl; try solve [destruct pc0; auto].
     eapply wf_loc_succ; eauto. constructor.
-  
+
     - (* Case "step_tmn". *)
     assert (wf_pc g (l', 0)) as Hwfpc'.
       inversion Hwff as [_ Hwfi _]. specialize (Hwfi _ _ H).
-      inversion Hwfi. red in Hlbl. apply Hlbl. 
+      inversion Hwfi. red in Hlbl. apply Hlbl.
       eauto. eapply eval_tmn_in_lbls. eauto.
 
     assert (succ_pc g pc0 (l', 0)) as Hsucc.


### PR DESCRIPTION
Because those who use `(setq-default show-trailing-whitespace t)` see all the trailing whitespaces in the code:

![4](https://user-images.githubusercontent.com/1597921/28283488-c4e43a16-6b25-11e7-812f-fa00bfb23f66.png)

And it's actually a good idea to add  `(setq-default show-trailing-whitespace t)` to your `.emacs` file to see when you accidentally introduce trailing whitespaces :-)