### PR TITLE
Fix a simple typo in QC.v

### DIFF
--- a/qc/QC.v
+++ b/qc/QC.v
@@ -925,7 +925,7 @@ Instance shrinkTree {A} `{Shrink A} : Shrink (Tree A) :=
 (* QuickChick 
      (forAllShrink 
         (genTreeSized' 5 (choose (0,5))) 
-        (shrinkTree shrink) 
+        shrink
         faultyMirrorP). *)
 (** 
 ===> 


### PR DESCRIPTION
With this change the `QuickCheck` directive works when uncommented.  Without the change, it gives a fairly strange error that took us a little while to figure out.