### PR TITLE
"Bar" is mapped to "true" below, not "foo".

### DIFF
--- a/SF/lf/Maps.html
+++ b/SF/lf/Maps.html
@@ -270,7 +270,7 @@ This definition is a nice example of higher-order programming:
 <div class="paragraph"> </div>
 
     For example, we can build a map taking <span class="inlinecode"><span class="id" type="var">id</span></span>s to <span class="inlinecode"><span class="id" type="var">bool</span></span>s, where <span class="inlinecode"><span class="id" type="var">Id</span></span>
-    <span class="inlinecode">"<span class="id" type="var">foo</span>"</span> is mapped to <span class="inlinecode"><span class="id" type="var">true</span></span> and every other key is mapped to <span class="inlinecode"><span class="id" type="var">false</span></span>,
+    <span class="inlinecode">"<span class="id" type="var">bar</span>"</span> is mapped to <span class="inlinecode"><span class="id" type="var">true</span></span> and every other key is mapped to <span class="inlinecode"><span class="id" type="var">false</span></span>,
     like this: 
 </div>
 <div class="code code-tight">

--- a/SF/lf/Maps.v
+++ b/SF/lf/Maps.v
@@ -149,7 +149,7 @@ Definition t_update {A:Type} (m : total_map A)
     [fun x' => ...] that behaves like the desired map.
 
     For example, we can build a map taking [id]s to [bool]s, where [Id
-    "foo"] is mapped to [true] and every other key is mapped to [false],
+    "bar"] is mapped to [true] and every other key is mapped to [false],
     like this: *)
 
 Definition examplemap :=


### PR DESCRIPTION
It's clear from the definition and the examples below that "bar" (not "foo") is mapped to true.